### PR TITLE
feat: render markdown in preview pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .DS_Store
 .superpowers/
 demo.cast
+docs/superpowers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "pulldown-cmark",
  "ratatui",
  "tempfile",
 ]
@@ -532,6 +533,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +805,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ ratatui = "0.29"
 crossterm = "0.28"
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
+pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -9,6 +9,8 @@ use ratatui::{Terminal, backend::TestBackend, style::Color};
 
 #[path = "../src/app.rs"]
 mod app;
+#[path = "../src/markdown.rs"]
+mod markdown;
 #[path = "../src/scan.rs"]
 mod scan;
 #[path = "../src/theme.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod markdown;
 mod scan;
 mod theme;
 mod ui;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,0 +1,606 @@
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+
+use crate::theme::Theme;
+
+/// Render a markdown string into a styled `Text` suitable for a ratatui `Paragraph`.
+pub fn render_markdown(input: &str, theme: &Theme) -> Text<'static> {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    let parser = Parser::new_ext(input, options);
+    let mut renderer = Renderer::new(theme);
+    for event in parser {
+        renderer.handle(event);
+    }
+    renderer.finalize()
+}
+
+struct Renderer<'a> {
+    theme: &'a Theme,
+    lines: Vec<Line<'static>>,
+    current: Vec<Span<'static>>,
+    style_stack: Vec<Style>,
+    in_code_block: bool,
+    pending_link_url: Option<String>,
+    list_stack: Vec<Option<u64>>,
+    item_prefix_pending: bool,
+    blockquote_depth: usize,
+}
+
+impl<'a> Renderer<'a> {
+    fn new(theme: &'a Theme) -> Self {
+        Self {
+            theme,
+            lines: Vec::new(),
+            current: Vec::new(),
+            style_stack: Vec::new(),
+            in_code_block: false,
+            pending_link_url: None,
+            list_stack: Vec::new(),
+            item_prefix_pending: false,
+            blockquote_depth: 0,
+        }
+    }
+
+    fn current_style(&self) -> Style {
+        self.style_stack
+            .last()
+            .copied()
+            .unwrap_or_else(|| Style::default().fg(self.theme.text))
+    }
+
+    fn push_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        self.start_line_if_needed();
+        let style = self.current_style();
+        self.current.push(Span::styled(text.to_string(), style));
+    }
+
+    fn start_line_if_needed(&mut self) {
+        if !self.current.is_empty() {
+            return;
+        }
+        if self.blockquote_depth > 0 {
+            let prefix = "▎ ".repeat(self.blockquote_depth);
+            let style = Style::default().fg(self.theme.muted);
+            self.current.push(Span::styled(prefix, style));
+        }
+        if self.item_prefix_pending {
+            self.item_prefix_pending = false;
+            self.emit_item_prefix();
+        }
+    }
+
+    fn emit_item_prefix(&mut self) {
+        let depth = self.list_stack.len().saturating_sub(1);
+        let indent = "  ".repeat(depth);
+        let prefix = match self.list_stack.last_mut() {
+            Some(Some(counter)) => {
+                let n = *counter;
+                *counter += 1;
+                format!("{indent}{n}. ")
+            }
+            Some(None) => {
+                format!("{indent}• ")
+            }
+            None => String::new(),
+        };
+        if !prefix.is_empty() {
+            let style = self.current_style();
+            self.current.push(Span::styled(prefix, style));
+        }
+    }
+
+    fn heading_style(&self, level: HeadingLevel) -> Style {
+        let color = match level {
+            HeadingLevel::H1 => self.theme.iris,
+            HeadingLevel::H2 => self.theme.foam,
+            HeadingLevel::H3 | HeadingLevel::H4 | HeadingLevel::H5 | HeadingLevel::H6 => {
+                self.theme.gold
+            }
+        };
+        Style::default().fg(color).add_modifier(Modifier::BOLD)
+    }
+
+    fn push_style(&mut self, transform: impl FnOnce(Style, &Theme) -> Style) {
+        let base = self.current_style();
+        let next = transform(base, self.theme);
+        self.style_stack.push(next);
+    }
+
+    fn flush_line(&mut self) {
+        let spans = std::mem::take(&mut self.current);
+        self.lines.push(Line::from(spans));
+    }
+
+    fn blank_line(&mut self) {
+        self.lines.push(Line::default());
+    }
+
+    fn handle(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(TagEnd::Paragraph) => {
+                self.flush_line();
+                if self.list_stack.is_empty() {
+                    self.blank_line();
+                }
+            }
+            Event::Start(Tag::List(start)) => {
+                if !self.current.is_empty() {
+                    self.flush_line();
+                }
+                self.list_stack.push(start);
+            }
+            Event::End(TagEnd::List(_)) => {
+                self.list_stack.pop();
+                if self.list_stack.is_empty() {
+                    self.blank_line();
+                }
+            }
+            Event::Start(Tag::Item) => {
+                if !self.current.is_empty() {
+                    self.flush_line();
+                }
+                self.item_prefix_pending = true;
+            }
+            Event::End(TagEnd::Item) => {
+                self.flush_line();
+            }
+            Event::TaskListMarker(done) => {
+                self.item_prefix_pending = false;
+                let depth = self.list_stack.len().saturating_sub(1);
+                let indent = "  ".repeat(depth);
+                if !indent.is_empty() {
+                    let style = self.current_style();
+                    self.current.push(Span::styled(indent, style));
+                }
+                let (marker, color) = if done {
+                    ("[x] ", self.theme.pine)
+                } else {
+                    ("[ ] ", self.theme.muted)
+                };
+                let style = Style::default().fg(color);
+                self.current.push(Span::styled(marker.to_string(), style));
+            }
+            Event::Start(Tag::BlockQuote(_)) => {
+                if !self.current.is_empty() {
+                    self.flush_line();
+                }
+                self.blockquote_depth += 1;
+                self.push_style(|s, theme| s.fg(theme.muted).add_modifier(Modifier::ITALIC));
+            }
+            Event::End(TagEnd::BlockQuote(_)) => {
+                self.style_stack.pop();
+                self.blockquote_depth = self.blockquote_depth.saturating_sub(1);
+                if self.blockquote_depth == 0 {
+                    self.blank_line();
+                }
+            }
+            Event::Rule => {
+                if !self.current.is_empty() {
+                    self.flush_line();
+                }
+                let style = Style::default().fg(self.theme.muted);
+                let rule = "─".repeat(80);
+                self.current.push(Span::styled(rule, style));
+                self.flush_line();
+                self.blank_line();
+            }
+            Event::Start(Tag::Heading { level, .. }) => {
+                self.style_stack.push(self.heading_style(level));
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                self.style_stack.pop();
+                self.flush_line();
+                self.blank_line();
+            }
+            Event::Start(Tag::Strong) => {
+                self.push_style(|s, _| s.add_modifier(Modifier::BOLD));
+            }
+            Event::End(TagEnd::Strong) => {
+                self.style_stack.pop();
+            }
+            Event::Start(Tag::Emphasis) => {
+                self.push_style(|s, _| s.add_modifier(Modifier::ITALIC));
+            }
+            Event::End(TagEnd::Emphasis) => {
+                self.style_stack.pop();
+            }
+            Event::Start(Tag::Strikethrough) => {
+                self.push_style(|s, theme| {
+                    s.fg(theme.muted).add_modifier(Modifier::CROSSED_OUT)
+                });
+            }
+            Event::End(TagEnd::Strikethrough) => {
+                self.style_stack.pop();
+            }
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                self.pending_link_url = Some(dest_url.to_string());
+                self.push_style(|s, theme| s.fg(theme.foam).add_modifier(Modifier::UNDERLINED));
+            }
+            Event::End(TagEnd::Link) => {
+                self.style_stack.pop();
+                if let Some(url) = self.pending_link_url.take() {
+                    let muted = Style::default().fg(self.theme.muted);
+                    self.current
+                        .push(Span::styled(format!(" ({url})"), muted));
+                }
+            }
+            Event::Code(text) => {
+                self.start_line_if_needed();
+                let style = Style::default()
+                    .fg(self.theme.rose)
+                    .bg(self.theme.overlay);
+                self.current.push(Span::styled(text.to_string(), style));
+            }
+            Event::Start(Tag::CodeBlock(_)) => {
+                if !self.current.is_empty() {
+                    self.flush_line();
+                }
+                self.in_code_block = true;
+                let code_style = Style::default()
+                    .fg(self.theme.rose)
+                    .bg(self.theme.surface);
+                self.style_stack.push(code_style);
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                self.style_stack.pop();
+                self.in_code_block = false;
+                self.blank_line();
+            }
+            Event::Text(text) => {
+                if self.in_code_block {
+                    let content = text.as_ref();
+                    let mut first = true;
+                    for segment in content.split('\n') {
+                        if !first {
+                            self.flush_line();
+                        }
+                        if !segment.is_empty() {
+                            let style = self.current_style();
+                            self.current
+                                .push(Span::styled(segment.to_string(), style));
+                        }
+                        first = false;
+                    }
+                } else {
+                    self.push_text(text.as_ref());
+                }
+            }
+            Event::SoftBreak => {
+                self.push_text(" ");
+            }
+            Event::HardBreak => {
+                self.flush_line();
+            }
+            _ => {}
+        }
+    }
+
+    fn finalize(mut self) -> Text<'static> {
+        if !self.current.is_empty() {
+            self.flush_line();
+        }
+        // Trim trailing blank line added by the last End(Paragraph).
+        while self
+            .lines
+            .last()
+            .map(|l| l.spans.is_empty())
+            .unwrap_or(false)
+        {
+            self.lines.pop();
+        }
+        Text::from(self.lines)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn empty_input_produces_empty_text() {
+        let theme = Theme::dark();
+        let text = render_markdown("", &theme);
+        assert_eq!(text.lines.len(), 0);
+    }
+
+    #[test]
+    fn single_paragraph_produces_one_line_with_text_color() {
+        let theme = Theme::dark();
+        let text = render_markdown("hello world", &theme);
+        assert_eq!(text.lines.len(), 1);
+        assert_eq!(line_text(&text.lines[0]), "hello world");
+        let span = &text.lines[0].spans[0];
+        assert_eq!(span.style.fg, Some(theme.text));
+    }
+
+    #[test]
+    fn two_paragraphs_are_separated_by_blank_line() {
+        let theme = Theme::dark();
+        let text = render_markdown("first\n\nsecond", &theme);
+        assert_eq!(text.lines.len(), 3);
+        assert_eq!(line_text(&text.lines[0]), "first");
+        assert_eq!(line_text(&text.lines[1]), "");
+        assert_eq!(line_text(&text.lines[2]), "second");
+    }
+
+    #[test]
+    fn soft_break_becomes_single_space() {
+        let theme = Theme::dark();
+        let text = render_markdown("line one\nline two", &theme);
+        assert_eq!(text.lines.len(), 1);
+        assert_eq!(line_text(&text.lines[0]), "line one line two");
+    }
+
+    #[test]
+    fn hard_break_starts_new_line() {
+        let theme = Theme::dark();
+        let text = render_markdown("line one  \nline two", &theme);
+        assert_eq!(text.lines.len(), 2);
+        assert_eq!(line_text(&text.lines[0]), "line one");
+        assert_eq!(line_text(&text.lines[1]), "line two");
+    }
+
+    #[test]
+    fn h1_is_bold_iris() {
+        let theme = Theme::dark();
+        let text = render_markdown("# Title", &theme);
+        assert_eq!(text.lines.len(), 1);
+        assert_eq!(line_text(&text.lines[0]), "Title");
+        let span = &text.lines[0].spans[0];
+        assert_eq!(span.style.fg, Some(theme.iris));
+        assert!(span.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn h2_is_bold_foam() {
+        let theme = Theme::dark();
+        let text = render_markdown("## Subsection", &theme);
+        let span = &text.lines[0].spans[0];
+        assert_eq!(span.style.fg, Some(theme.foam));
+        assert!(span.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn h3_through_h6_are_bold_gold() {
+        let theme = Theme::dark();
+        for prefix in ["### ", "#### ", "##### ", "###### "] {
+            let text = render_markdown(&format!("{prefix}Heading"), &theme);
+            let span = &text.lines[0].spans[0];
+            assert_eq!(span.style.fg, Some(theme.gold));
+            assert!(span.style.add_modifier.contains(Modifier::BOLD));
+        }
+    }
+
+    #[test]
+    fn bold_adds_bold_modifier() {
+        let theme = Theme::dark();
+        let text = render_markdown("a **bold** word", &theme);
+        let spans = &text.lines[0].spans;
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[1].content.as_ref(), "bold");
+        assert!(spans[1].style.add_modifier.contains(Modifier::BOLD));
+        assert!(!spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn italic_adds_italic_modifier() {
+        let theme = Theme::dark();
+        let text = render_markdown("a *slanted* word", &theme);
+        let spans = &text.lines[0].spans;
+        assert_eq!(spans[1].content.as_ref(), "slanted");
+        assert!(spans[1].style.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn strikethrough_uses_muted_and_crossed_out() {
+        let theme = Theme::dark();
+        let text = render_markdown("a ~~gone~~ word", &theme);
+        let spans = &text.lines[0].spans;
+        assert_eq!(spans[1].content.as_ref(), "gone");
+        assert!(spans[1].style.add_modifier.contains(Modifier::CROSSED_OUT));
+        assert_eq!(spans[1].style.fg, Some(theme.muted));
+    }
+
+    #[test]
+    fn bold_inside_heading_keeps_heading_color() {
+        let theme = Theme::dark();
+        let text = render_markdown("# A **B** C", &theme);
+        let spans = &text.lines[0].spans;
+        for span in spans {
+            assert_eq!(span.style.fg, Some(theme.iris));
+        }
+        assert_eq!(spans[1].content.as_ref(), "B");
+        assert!(spans[1].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn inline_code_is_rose_on_overlay() {
+        let theme = Theme::dark();
+        let text = render_markdown("use `foo()` here", &theme);
+        let spans = &text.lines[0].spans;
+        let code_span = spans
+            .iter()
+            .find(|s| s.content.as_ref() == "foo()")
+            .expect("code span missing");
+        assert_eq!(code_span.style.fg, Some(theme.rose));
+        assert_eq!(code_span.style.bg, Some(theme.overlay));
+    }
+
+    #[test]
+    fn fenced_code_block_is_rose_on_surface_multi_line() {
+        let theme = Theme::dark();
+        let input = "```\nlet x = 1;\nlet y = 2;\n```";
+        let text = render_markdown(input, &theme);
+        let code_lines: Vec<&Line> = text
+            .lines
+            .iter()
+            .filter(|l| !l.spans.is_empty())
+            .collect();
+        assert_eq!(code_lines.len(), 2);
+        assert_eq!(line_text(code_lines[0]), "let x = 1;");
+        assert_eq!(line_text(code_lines[1]), "let y = 2;");
+        for line in &code_lines {
+            for span in &line.spans {
+                assert_eq!(span.style.fg, Some(theme.rose));
+                assert_eq!(span.style.bg, Some(theme.surface));
+            }
+        }
+    }
+
+    #[test]
+    fn code_block_preserves_blank_lines_inside() {
+        let theme = Theme::dark();
+        let input = "```\na\n\nb\n```";
+        let text = render_markdown(input, &theme);
+        let first_three: Vec<String> = text.lines.iter().take(3).map(line_text).collect();
+        assert_eq!(
+            first_three,
+            vec!["a".to_string(), String::new(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn link_text_is_foam_underlined_with_url_suffix() {
+        let theme = Theme::dark();
+        let text = render_markdown("see [docs](https://example.com) now", &theme);
+        let spans = &text.lines[0].spans;
+
+        let link_text = spans
+            .iter()
+            .find(|s| s.content.as_ref() == "docs")
+            .expect("link text span missing");
+        assert_eq!(link_text.style.fg, Some(theme.foam));
+        assert!(link_text.style.add_modifier.contains(Modifier::UNDERLINED));
+
+        let url_span = spans
+            .iter()
+            .find(|s| s.content.as_ref().contains("https://example.com"))
+            .expect("url suffix missing");
+        assert_eq!(url_span.style.fg, Some(theme.muted));
+    }
+
+    #[test]
+    fn unordered_list_items_get_bullet_prefix() {
+        let theme = Theme::dark();
+        let text = render_markdown("- first\n- second", &theme);
+        let lines: Vec<String> = text.lines.iter().map(line_text).collect();
+        assert!(lines.contains(&"• first".to_string()));
+        assert!(lines.contains(&"• second".to_string()));
+    }
+
+    #[test]
+    fn ordered_list_items_get_numbered_prefix() {
+        let theme = Theme::dark();
+        let text = render_markdown("1. a\n2. b\n3. c", &theme);
+        let lines: Vec<String> = text.lines.iter().map(line_text).collect();
+        assert!(lines.contains(&"1. a".to_string()));
+        assert!(lines.contains(&"2. b".to_string()));
+        assert!(lines.contains(&"3. c".to_string()));
+    }
+
+    #[test]
+    fn ordered_list_respects_start_value() {
+        let theme = Theme::dark();
+        let text = render_markdown("5. a\n6. b", &theme);
+        let lines: Vec<String> = text.lines.iter().map(line_text).collect();
+        assert!(lines.contains(&"5. a".to_string()));
+        assert!(lines.contains(&"6. b".to_string()));
+    }
+
+    #[test]
+    fn nested_list_indents_inner_items() {
+        let theme = Theme::dark();
+        let input = "- outer\n  - inner";
+        let text = render_markdown(input, &theme);
+        let lines: Vec<String> = text.lines.iter().map(line_text).collect();
+        assert!(lines.contains(&"• outer".to_string()));
+        assert!(lines.iter().any(|l| l == "  • inner"));
+    }
+
+    #[test]
+    fn task_list_open_uses_muted_marker() {
+        let theme = Theme::dark();
+        let text = render_markdown("- [ ] todo", &theme);
+        let line = &text.lines[0];
+        let marker = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref().contains("[ ]"))
+            .expect("open marker missing");
+        assert_eq!(marker.style.fg, Some(theme.muted));
+    }
+
+    #[test]
+    fn task_list_done_uses_pine_marker() {
+        let theme = Theme::dark();
+        let text = render_markdown("- [x] done", &theme);
+        let line = &text.lines[0];
+        let marker = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref().contains("[x]"))
+            .expect("done marker missing");
+        assert_eq!(marker.style.fg, Some(theme.pine));
+    }
+
+    #[test]
+    fn blockquote_is_muted_italic_with_bar_prefix() {
+        let theme = Theme::dark();
+        let text = render_markdown("> quoted line", &theme);
+        let line = &text.lines[0];
+        assert!(line_text(line).starts_with("▎ "));
+        let content_span = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref().contains("quoted line"))
+            .expect("quoted content missing");
+        assert_eq!(content_span.style.fg, Some(theme.muted));
+        assert!(content_span.style.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn multi_line_blockquote_prefixes_each_line() {
+        let theme = Theme::dark();
+        let text = render_markdown("> first\n>\n> second", &theme);
+        let contents: Vec<String> = text.lines.iter().map(line_text).collect();
+        assert!(
+            contents
+                .iter()
+                .any(|c| c.starts_with("▎ ") && c.contains("first"))
+        );
+        assert!(
+            contents
+                .iter()
+                .any(|c| c.starts_with("▎ ") && c.contains("second"))
+        );
+    }
+
+    #[test]
+    fn horizontal_rule_produces_muted_line_of_dashes() {
+        let theme = Theme::dark();
+        let text = render_markdown("one\n\n---\n\ntwo", &theme);
+        let rule_line = text
+            .lines
+            .iter()
+            .find(|l| {
+                let content = line_text(l);
+                !content.is_empty() && content.chars().all(|c| c == '─' || c.is_whitespace())
+            })
+            .expect("rule line missing");
+        let span = &rule_line.spans[0];
+        assert_eq!(span.style.fg, Some(theme.muted));
+        assert!(span.content.as_ref().contains('─'));
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,6 +7,7 @@ use ratatui::{
 };
 
 use crate::app::{App, Pane};
+use crate::markdown;
 use crate::theme::Theme;
 
 pub fn render(frame: &mut Frame, app: &App, theme: &Theme) {
@@ -125,7 +126,8 @@ fn render_preview_pane(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
         .unwrap_or("");
     let block = pane_block(file_name, focused, theme);
 
-    let paragraph = Paragraph::new(app.content.as_str())
+    let rendered = markdown::render_markdown(&app.content, theme);
+    let paragraph = Paragraph::new(rendered)
         .block(block)
         .style(Style::default().fg(theme.text).bg(theme.base))
         .wrap(Wrap { trim: false })


### PR DESCRIPTION
## Summary

- Adds `src/markdown.rs` — a `pulldown-cmark`-powered renderer that converts memory files into themed `ratatui::text::Text` (headings, emphasis, strikethrough, lists with nesting + task markers, inline/fenced code, links, blockquotes, rules).
- Wires the renderer into `render_preview_pane` so the preview pane now shows styled markdown instead of raw bytes.
- Closes #2.

## Element → Style Mapping (Rose Pine)

| Element | Style |
| --- | --- |
| H1 / H2 / H3-H6 | `iris` / `foam` / `gold` + bold |
| Strong / Emphasis / Strikethrough | `BOLD` / `ITALIC` / `muted` + `CROSSED_OUT` |
| Inline code | `rose` fg on `overlay` bg |
| Code block (fenced or indented) | `rose` fg on `surface` bg, each line becomes its own `Line` |
| Link | `foam` + underlined, URL appended as `muted` suffix |
| Blockquote | `muted` + italic, each line prefixed with `▎ ` |
| Unordered list | `• ` bullet, 2-space indent per depth |
| Ordered list | `N. ` number, 2-space indent per depth |
| Task list marker | `[ ]` muted / `[x]` pine (GFM tasklists) |
| Horizontal rule | `muted` line of `─` |

## Out of scope (follow-up)

- Tables, footnotes, raw HTML, images
- YAML frontmatter stripping for memory files

## Test plan

- [x] `cargo test` — 43/43 passing (25 new markdown tests + 18 pre-existing)
- [x] `cargo clippy -- -D warnings` — clean (matches CI)
- [x] `cargo build` — clean
- [x] `cargo run --example screenshot > out.svg` — verified themed output: H1 rendered in iris bold (`#c4a7e7`), H2 headings `Tech Stack` / `Build & Test` / `Key Conventions` in foam bold (`#9ccfd8`), bash code block with rose fg (`#ebbcba`) on surface bg (`#1f1d2e`), no leftover raw markdown syntax (`**`, backticks) in output