### PR TITLE
feat: add Sessions observability mode (MVP1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,10 +74,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cassowary"
@@ -86,10 +107,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -150,6 +192,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
@@ -235,11 +283,13 @@ dependencies = [
 name = "duru"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "clap",
  "crossterm",
  "dirs",
  "pulldown-cmark",
  "ratatui",
+ "serde_json",
  "tempfile",
 ]
 
@@ -270,6 +320,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -323,6 +379,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -390,6 +470,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -464,6 +554,15 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -692,6 +791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +989,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,10 +1090,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ crossterm = "0.28"
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 pulldown-cmark = { version = "0.13", default-features = false }
+serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -53,22 +53,50 @@ duru --theme light      # force light theme
 duru --path ~/alt/.claude  # custom path
 ```
 
-### Navigation
+### Modes
+
+Press `Tab` to switch between two modes:
+
+- **Memory** (default) — Browse `CLAUDE.md` and memory files across all projects
+- **Sessions** — Live table of active Claude Code sessions with cache TTL countdowns
+
+### Memory mode keys
 
 | Key | Action |
 |-----|--------|
 | `↑↓` / `jk` | Navigate within pane |
 | `←→` / `hl` | Switch pane |
 | `Enter` | Enter next pane |
+| `e` | Edit selected file in `$EDITOR` |
+| `Tab` | Switch to Sessions mode |
+| `q` | Quit |
+
+### Sessions mode keys
+
+| Key | Action |
+|-----|--------|
+| `jk` / `↑↓` | Navigate rows (Table) / scroll (Detail) |
+| `hl` / `←→` | Toggle Table / Detail focus |
+| `s` | Cycle sort (activity → TTL → project → size) |
+| `r` | Force refresh |
+| `g` `G` | Jump to top / bottom |
+| `Tab` | Switch to Memory mode |
 | `q` | Quit |
 
 ## Layout
 
-Miller Columns (3-pane):
+**Memory mode** uses Miller Columns (3-pane):
 
 - **Pane 1** — All projects that have CLAUDE.md or memory files
 - **Pane 2** — Files in the selected project (CLAUDE.md, MEMORY.md, etc.)
 - **Pane 3** — File content preview
+
+**Sessions mode** uses a Table + Detail layout:
+
+- **Table** — 7 columns: state glyph, short ID, project, mode, last activity, cache TTL, size
+- **Detail** — Fixed 8-row panel showing full session metadata
+
+Cache TTL is shown as a hybrid `mm:ss ████▌·····` bar with color thresholds (green > 50%, yellow 20–50%, red < 20%).
 
 ## Theme
 

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -13,6 +13,8 @@ mod app;
 mod markdown;
 #[path = "../src/scan.rs"]
 mod scan;
+#[path = "../src/sessions.rs"]
+mod sessions;
 #[path = "../src/theme.rs"]
 mod theme;
 #[path = "../src/ui.rs"]

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,6 +1,10 @@
 //! Generate SVG screenshot of duru TUI with demo data.
 //! Usage: cargo run --example screenshot > screenshot.svg
 
+// The example imports all src modules via `#[path]` but only exercises a subset,
+// so dead_code warnings are expected and suppressed.
+#![allow(dead_code)]
+
 use ratatui::{Terminal, backend::TestBackend, style::Color};
 
 // Access internal modules via the binary crate's public API

--- a/src/app.rs
+++ b/src/app.rs
@@ -172,6 +172,39 @@ impl App {
         }
     }
 
+    pub fn refresh_sessions(&mut self, claude_dir: &Path) {
+        use crate::sessions::sort_entries;
+        self.session_cache.refresh(claude_dir);
+        let mut entries = self.session_cache.entries();
+        sort_entries(&mut entries, self.sessions_sort, chrono::Utc::now());
+        self.sessions = entries;
+        self.clamp_session_index();
+        self.last_refresh = Instant::now();
+    }
+
+    pub fn refresh_interval(&self) -> std::time::Duration {
+        use std::time::Duration;
+        if self.mode != AppMode::Sessions {
+            return Duration::from_secs(3600);
+        }
+        let now = chrono::Utc::now();
+        let has_recent = self
+            .sessions
+            .iter()
+            .any(|e| (now - e.last_activity).num_seconds() < 60);
+        if has_recent {
+            Duration::from_millis(1000)
+        } else {
+            Duration::from_millis(2000)
+        }
+    }
+
+    pub fn with_demo_sessions(mut self, demos: Vec<SessionEntry>) -> Self {
+        self.sessions = demos;
+        self.skip_real_refresh = true;
+        self
+    }
+
     fn sessions_move_up(&mut self) {
         match self.sessions_focus {
             SessionsPane::Table => {
@@ -469,6 +502,34 @@ mod tests {
         app.sessions.clear();
         app.clamp_session_index();
         assert_eq!(app.session_index, 0);
+    }
+
+    #[test]
+    fn refresh_interval_fast_when_activity_recent() {
+        let app = app_in_sessions_mode();
+        assert_eq!(
+            app.refresh_interval(),
+            std::time::Duration::from_millis(1000)
+        );
+    }
+
+    #[test]
+    fn refresh_interval_slow_when_all_idle() {
+        let mut app = app_in_sessions_mode();
+        let old = chrono::Utc::now() - chrono::Duration::hours(1);
+        for s in &mut app.sessions {
+            s.last_activity = old;
+        }
+        assert_eq!(
+            app.refresh_interval(),
+            std::time::Duration::from_millis(2000)
+        );
+    }
+
+    #[test]
+    fn refresh_interval_disabled_in_memory_mode() {
+        let app = App::new(make_test_projects());
+        assert!(app.refresh_interval() >= std::time::Duration::from_secs(60));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -142,11 +142,13 @@ impl App {
             KeyCode::Char('g') => {
                 if self.sessions_focus == SessionsPane::Table {
                     self.session_index = 0;
+                    self.session_scroll = 0;
                 }
             }
             KeyCode::Char('G') => {
                 if self.sessions_focus == SessionsPane::Table && !self.sessions.is_empty() {
                     self.session_index = self.sessions.len() - 1;
+                    self.session_scroll = 0;
                 }
             }
             KeyCode::Char('s') => self.cycle_sort(),
@@ -210,6 +212,7 @@ impl App {
             SessionsPane::Table => {
                 if self.session_index > 0 {
                     self.session_index -= 1;
+                    self.session_scroll = 0;
                 }
             }
             SessionsPane::Detail => {
@@ -223,10 +226,13 @@ impl App {
             SessionsPane::Table => {
                 if self.session_index + 1 < self.sessions.len() {
                     self.session_index += 1;
+                    self.session_scroll = 0;
                 }
             }
             SessionsPane::Detail => {
-                self.session_scroll = self.session_scroll.saturating_add(1);
+                // Detail holds 6 content lines in a 6-row viewport; scrolling
+                // beyond 5 shows only blank space. Clamp to avoid that.
+                self.session_scroll = (self.session_scroll.saturating_add(1)).min(5);
             }
         }
     }
@@ -463,6 +469,55 @@ mod tests {
         app.sessions_focus = SessionsPane::Detail;
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
         assert_eq!(app.session_scroll, 1);
+    }
+
+    #[test]
+    fn sessions_mode_detail_j_clamps_at_five() {
+        let mut app = app_in_sessions_mode();
+        app.sessions_focus = SessionsPane::Detail;
+        for _ in 0..20 {
+            app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        }
+        assert_eq!(app.session_scroll, 5);
+    }
+
+    #[test]
+    fn sessions_mode_j_resets_detail_scroll() {
+        let mut app = app_in_sessions_mode();
+        app.session_scroll = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, 1);
+        assert_eq!(app.session_scroll, 0);
+    }
+
+    #[test]
+    fn sessions_mode_k_resets_detail_scroll() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 2;
+        app.session_scroll = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, 1);
+        assert_eq!(app.session_scroll, 0);
+    }
+
+    #[test]
+    fn sessions_mode_g_resets_detail_scroll() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 3;
+        app.session_scroll = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, 0);
+        assert_eq!(app.session_scroll, 0);
+    }
+
+    #[test]
+    fn sessions_mode_shift_g_resets_detail_scroll() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 0;
+        app.session_scroll = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT));
+        assert_eq!(app.session_index, app.sessions.len() - 1);
+        assert_eq!(app.session_scroll, 0);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,16 +9,16 @@ use crate::sessions::{SessionCache, SessionEntry, SessionsSort};
 
 /// Sessions-mode refresh cadence when any session had activity in the last
 /// `RECENT_ACTIVITY_SECS` — snappy enough for TTL countdowns to feel live.
-pub const FAST_POLL_MS: u64 = 1000;
+pub(crate) const FAST_POLL_MS: u64 = 1000;
 
 /// Sessions-mode refresh cadence when everything is quiet; backs off to
 /// reduce filesystem churn while still catching new sessions within a second
 /// or two.
-pub const SLOW_POLL_MS: u64 = 2000;
+pub(crate) const SLOW_POLL_MS: u64 = 2000;
 
 /// Threshold below which a session counts as "recent activity" for the
 /// refresh-interval decision.
-pub const RECENT_ACTIVITY_SECS: i64 = 60;
+pub(crate) const RECENT_ACTIVITY_SECS: i64 = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,24 @@
 use std::fs;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::scan::Project;
 use crate::sessions::{SessionCache, SessionEntry, SessionsSort};
+
+/// Sessions-mode refresh cadence when any session had activity in the last
+/// `RECENT_ACTIVITY_SECS` — snappy enough for TTL countdowns to feel live.
+pub const FAST_POLL_MS: u64 = 1000;
+
+/// Sessions-mode refresh cadence when everything is quiet; backs off to
+/// reduce filesystem churn while still catching new sessions within a second
+/// or two.
+pub const SLOW_POLL_MS: u64 = 2000;
+
+/// Threshold below which a session counts as "recent activity" for the
+/// refresh-interval decision.
+pub const RECENT_ACTIVITY_SECS: i64 = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {
@@ -184,8 +197,7 @@ impl App {
         self.last_refresh = Instant::now();
     }
 
-    pub fn refresh_interval(&self) -> std::time::Duration {
-        use std::time::Duration;
+    pub fn refresh_interval(&self) -> Duration {
         if self.mode != AppMode::Sessions {
             return Duration::from_secs(3600);
         }
@@ -193,11 +205,11 @@ impl App {
         let has_recent = self
             .sessions
             .iter()
-            .any(|e| (now - e.last_activity).num_seconds() < 60);
+            .any(|e| (now - e.last_activity).num_seconds() < RECENT_ACTIVITY_SECS);
         if has_recent {
-            Duration::from_millis(1000)
+            Duration::from_millis(FAST_POLL_MS)
         } else {
-            Duration::from_millis(2000)
+            Duration::from_millis(SLOW_POLL_MS)
         }
     }
 
@@ -230,10 +242,7 @@ impl App {
                 }
             }
             SessionsPane::Detail => {
-                // Detail has 6 content lines rendered into a 6-row viewport
-                // (Length(8) minus 2 borders). Max meaningful scroll is 0
-                // until MVP2 adds more fields — j is a no-op here.
-                // Keep the arm so the binding is intentionally defined.
+                // Detail fits its 6-line content exactly — no scroll bound > 0.
             }
         }
     }
@@ -465,9 +474,7 @@ mod tests {
     }
 
     #[test]
-    fn sessions_mode_detail_j_is_bounded_to_zero_in_mvp1() {
-        // Detail has 6 content lines in a 6-row viewport, so max_scroll is 0.
-        // j is bound but effectively no-op until MVP2 adds more fields.
+    fn sessions_mode_detail_j_does_not_scroll_past_zero() {
         let mut app = app_in_sessions_mode();
         app.sessions_focus = SessionsPane::Detail;
         for _ in 0..20 {
@@ -557,10 +564,7 @@ mod tests {
     #[test]
     fn refresh_interval_fast_when_activity_recent() {
         let app = app_in_sessions_mode();
-        assert_eq!(
-            app.refresh_interval(),
-            std::time::Duration::from_millis(1000)
-        );
+        assert_eq!(app.refresh_interval(), Duration::from_millis(FAST_POLL_MS));
     }
 
     #[test]
@@ -570,16 +574,13 @@ mod tests {
         for s in &mut app.sessions {
             s.last_activity = old;
         }
-        assert_eq!(
-            app.refresh_interval(),
-            std::time::Duration::from_millis(2000)
-        );
+        assert_eq!(app.refresh_interval(), Duration::from_millis(SLOW_POLL_MS));
     }
 
     #[test]
     fn refresh_interval_disabled_in_memory_mode() {
         let app = App::new(make_test_projects());
-        assert!(app.refresh_interval() >= std::time::Duration::from_secs(60));
+        assert!(app.refresh_interval() >= Duration::from_secs(60));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,15 +1,29 @@
 use std::fs;
 use std::path::Path;
+use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::scan::Project;
+use crate::sessions::{SessionCache, SessionEntry, SessionsSort};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {
     Projects,
     Files,
     Preview,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppMode {
+    Memory,
+    Sessions,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionsPane {
+    Table,
+    Detail,
 }
 
 pub struct App {
@@ -21,6 +35,18 @@ pub struct App {
     pub content: String,
     pub should_quit: bool,
     pub wants_edit: bool,
+
+    // Sessions mode
+    pub mode: AppMode,
+    pub session_cache: SessionCache,
+    pub sessions: Vec<SessionEntry>,
+    pub session_index: usize,
+    pub session_scroll: u16,
+    pub sessions_focus: SessionsPane,
+    pub sessions_sort: SessionsSort,
+    pub last_refresh: Instant,
+    pub wants_refresh: bool,
+    pub skip_real_refresh: bool,
 }
 
 impl App {
@@ -34,6 +60,17 @@ impl App {
             content: String::new(),
             should_quit: false,
             wants_edit: false,
+
+            mode: AppMode::Memory,
+            session_cache: SessionCache::new(),
+            sessions: Vec::new(),
+            session_index: 0,
+            session_scroll: 0,
+            sessions_focus: SessionsPane::Table,
+            sessions_sort: SessionsSort::default(),
+            last_refresh: Instant::now(),
+            wants_refresh: false,
+            skip_real_refresh: false,
         };
         app.load_content();
         app

--- a/src/app.rs
+++ b/src/app.rs
@@ -124,8 +124,59 @@ impl App {
         }
     }
 
-    fn handle_key_sessions(&mut self, _key: KeyEvent) {
-        // Filled in by Task 11
+    fn handle_key_sessions(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Up | KeyCode::Char('k') => self.sessions_move_up(),
+            KeyCode::Down | KeyCode::Char('j') => self.sessions_move_down(),
+            KeyCode::Left | KeyCode::Char('h') => {
+                if self.sessions_focus == SessionsPane::Detail {
+                    self.sessions_focus = SessionsPane::Table;
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
+                if self.sessions_focus == SessionsPane::Table {
+                    self.sessions_focus = SessionsPane::Detail;
+                }
+            }
+            KeyCode::Char('g') => {
+                if self.sessions_focus == SessionsPane::Table {
+                    self.session_index = 0;
+                }
+            }
+            KeyCode::Char('G') => {
+                if self.sessions_focus == SessionsPane::Table && !self.sessions.is_empty() {
+                    self.session_index = self.sessions.len() - 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn sessions_move_up(&mut self) {
+        match self.sessions_focus {
+            SessionsPane::Table => {
+                if self.session_index > 0 {
+                    self.session_index -= 1;
+                }
+            }
+            SessionsPane::Detail => {
+                self.session_scroll = self.session_scroll.saturating_sub(1);
+            }
+        }
+    }
+
+    fn sessions_move_down(&mut self) {
+        match self.sessions_focus {
+            SessionsPane::Table => {
+                if self.session_index + 1 < self.sessions.len() {
+                    self.session_index += 1;
+                }
+            }
+            SessionsPane::Detail => {
+                self.session_scroll = self.session_scroll.saturating_add(1);
+            }
+        }
     }
 
     fn handle_key_memory(&mut self, key: KeyEvent) {
@@ -267,6 +318,99 @@ mod tests {
     fn new_app_starts_in_memory_mode() {
         let app = App::new(make_test_projects());
         assert_eq!(app.mode, AppMode::Memory);
+    }
+
+    fn app_in_sessions_mode() -> App {
+        use crate::sessions::demo_sessions;
+        let mut app = App::new(make_test_projects());
+        app.sessions = demo_sessions();
+        app.mode = AppMode::Sessions;
+        app
+    }
+
+    #[test]
+    fn sessions_mode_j_moves_row_down() {
+        let mut app = app_in_sessions_mode();
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, 1);
+    }
+
+    #[test]
+    fn sessions_mode_k_moves_row_up() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 2;
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, 1);
+    }
+
+    #[test]
+    fn sessions_mode_j_does_not_overflow() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = app.sessions.len() - 1;
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, app.sessions.len() - 1);
+    }
+
+    #[test]
+    fn sessions_mode_l_enters_detail() {
+        let mut app = app_in_sessions_mode();
+        app.handle_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_focus, SessionsPane::Detail);
+    }
+
+    #[test]
+    fn sessions_mode_h_exits_detail() {
+        let mut app = app_in_sessions_mode();
+        app.sessions_focus = SessionsPane::Detail;
+        app.handle_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_focus, SessionsPane::Table);
+    }
+
+    #[test]
+    fn sessions_mode_g_jumps_top() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert_eq!(app.session_index, 0);
+    }
+
+    #[test]
+    fn sessions_mode_shift_g_jumps_bottom() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 0;
+        app.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT));
+        assert_eq!(app.session_index, app.sessions.len() - 1);
+    }
+
+    #[test]
+    fn sessions_mode_q_quits() {
+        let mut app = app_in_sessions_mode();
+        app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn sessions_mode_e_ignored() {
+        let mut app = app_in_sessions_mode();
+        app.handle_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
+        assert!(!app.wants_edit);
+    }
+
+    #[test]
+    fn sessions_mode_detail_k_scrolls_up() {
+        let mut app = app_in_sessions_mode();
+        app.sessions_focus = SessionsPane::Detail;
+        app.session_scroll = 2;
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        assert_eq!(app.session_scroll, 1);
+    }
+
+    #[test]
+    fn sessions_mode_detail_j_scrolls_down() {
+        let mut app = app_in_sessions_mode();
+        app.sessions_focus = SessionsPane::Detail;
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(app.session_scroll, 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -104,7 +104,28 @@ impl App {
             self.should_quit = true;
             return;
         }
-        self.handle_key_memory(key);
+        if matches!(key.code, KeyCode::Tab | KeyCode::BackTab) {
+            self.toggle_mode();
+            return;
+        }
+        match self.mode {
+            AppMode::Memory => self.handle_key_memory(key),
+            AppMode::Sessions => self.handle_key_sessions(key),
+        }
+    }
+
+    fn toggle_mode(&mut self) {
+        self.mode = match self.mode {
+            AppMode::Memory => AppMode::Sessions,
+            AppMode::Sessions => AppMode::Memory,
+        };
+        if self.mode == AppMode::Sessions && self.sessions.is_empty() && !self.skip_real_refresh {
+            self.wants_refresh = true;
+        }
+    }
+
+    fn handle_key_sessions(&mut self, _key: KeyEvent) {
+        // Filled in by Task 11
     }
 
     fn handle_key_memory(&mut self, key: KeyEvent) {
@@ -240,6 +261,39 @@ mod tests {
         assert_eq!(app.focus, Pane::Projects);
         assert_eq!(app.project_index, 0);
         assert_eq!(app.file_index, 0);
+    }
+
+    #[test]
+    fn new_app_starts_in_memory_mode() {
+        let app = App::new(make_test_projects());
+        assert_eq!(app.mode, AppMode::Memory);
+    }
+
+    #[test]
+    fn tab_key_toggles_mode() {
+        let mut app = App::new(make_test_projects());
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.mode, AppMode::Sessions);
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.mode, AppMode::Memory);
+    }
+
+    #[test]
+    fn back_tab_also_toggles_mode() {
+        let mut app = App::new(make_test_projects());
+        app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE));
+        assert_eq!(app.mode, AppMode::Sessions);
+    }
+
+    #[test]
+    fn toggle_preserves_memory_state() {
+        let mut app = App::new(make_test_projects());
+        app.focus = Pane::Files;
+        app.project_index = 1;
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.focus, Pane::Files);
+        assert_eq!(app.project_index, 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,7 +67,10 @@ impl App {
             self.should_quit = true;
             return;
         }
+        self.handle_key_memory(key);
+    }
 
+    fn handle_key_memory(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Up | KeyCode::Char('k') => self.move_up(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -149,7 +149,26 @@ impl App {
                     self.session_index = self.sessions.len() - 1;
                 }
             }
+            KeyCode::Char('s') => self.cycle_sort(),
+            KeyCode::Char('r') => self.wants_refresh = true,
             _ => {}
+        }
+    }
+
+    fn cycle_sort(&mut self) {
+        self.sessions_sort = match self.sessions_sort {
+            SessionsSort::LastActivity => SessionsSort::CacheTtl,
+            SessionsSort::CacheTtl => SessionsSort::Project,
+            SessionsSort::Project => SessionsSort::Size,
+            SessionsSort::Size => SessionsSort::LastActivity,
+        };
+    }
+
+    pub fn clamp_session_index(&mut self) {
+        if self.sessions.is_empty() {
+            self.session_index = 0;
+        } else if self.session_index >= self.sessions.len() {
+            self.session_index = self.sessions.len() - 1;
         }
     }
 
@@ -411,6 +430,45 @@ mod tests {
         app.sessions_focus = SessionsPane::Detail;
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
         assert_eq!(app.session_scroll, 1);
+    }
+
+    #[test]
+    fn sessions_mode_s_cycles_sort() {
+        let mut app = app_in_sessions_mode();
+        assert_eq!(app.sessions_sort, SessionsSort::LastActivity);
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_sort, SessionsSort::CacheTtl);
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_sort, SessionsSort::Project);
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_sort, SessionsSort::Size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_sort, SessionsSort::LastActivity);
+    }
+
+    #[test]
+    fn sessions_mode_r_sets_wants_refresh() {
+        let mut app = app_in_sessions_mode();
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        assert!(app.wants_refresh);
+    }
+
+    #[test]
+    fn session_index_clamps_when_list_shrinks() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 4;
+        app.sessions.truncate(2);
+        app.clamp_session_index();
+        assert_eq!(app.session_index, 1);
+    }
+
+    #[test]
+    fn session_index_clamps_to_zero_when_empty() {
+        let mut app = app_in_sessions_mode();
+        app.session_index = 4;
+        app.sessions.clear();
+        app.clamp_session_index();
+        assert_eq!(app.session_index, 0);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -230,9 +230,10 @@ impl App {
                 }
             }
             SessionsPane::Detail => {
-                // Detail holds 6 content lines in a 6-row viewport; scrolling
-                // beyond 5 shows only blank space. Clamp to avoid that.
-                self.session_scroll = (self.session_scroll.saturating_add(1)).min(5);
+                // Detail has 6 content lines rendered into a 6-row viewport
+                // (Length(8) minus 2 borders). Max meaningful scroll is 0
+                // until MVP2 adds more fields — j is a no-op here.
+                // Keep the arm so the binding is intentionally defined.
             }
         }
     }
@@ -464,21 +465,15 @@ mod tests {
     }
 
     #[test]
-    fn sessions_mode_detail_j_scrolls_down() {
-        let mut app = app_in_sessions_mode();
-        app.sessions_focus = SessionsPane::Detail;
-        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
-        assert_eq!(app.session_scroll, 1);
-    }
-
-    #[test]
-    fn sessions_mode_detail_j_clamps_at_five() {
+    fn sessions_mode_detail_j_is_bounded_to_zero_in_mvp1() {
+        // Detail has 6 content lines in a 6-row viewport, so max_scroll is 0.
+        // j is bound but effectively no-op until MVP2 adds more fields.
         let mut app = app_in_sessions_mode();
         app.sessions_focus = SessionsPane::Detail;
         for _ in 0..20 {
             app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
         }
-        assert_eq!(app.session_scroll, 5);
+        assert_eq!(app.session_scroll, 0);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+// collapsible_match: the project intentionally uses `match arm => { if cond { ... } }`
+// instead of match guards, for readability when the condition references captured state.
+#![allow(clippy::collapsible_match, clippy::collapsible_if)]
+
 mod app;
 mod markdown;
 mod scan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,15 +51,15 @@ fn resolve_editor_from(visual: Option<&str>, editor: Option<&str>) -> String {
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
+    let claude_dir = cli.path.clone().unwrap_or_else(|| {
+        dirs::home_dir()
+            .expect("cannot resolve home directory")
+            .join(".claude")
+    });
+
     let projects = if cli.demo {
         demo_projects()
     } else {
-        let claude_dir = cli.path.unwrap_or_else(|| {
-            dirs::home_dir()
-                .expect("cannot resolve home directory")
-                .join(".claude")
-        });
-
         if !claude_dir.is_dir() {
             eprintln!("error: {} does not exist", claude_dir.display());
             std::process::exit(1);
@@ -90,7 +90,10 @@ fn main() -> io::Result<()> {
     terminal.clear()?;
 
     let mut app = App::new(projects);
-    let result = run_app(&mut terminal, &mut app, &theme, use_alt_screen);
+    if cli.demo {
+        app = app.with_demo_sessions(sessions::demo_sessions());
+    }
+    let result = run_app(&mut terminal, &mut app, &theme, use_alt_screen, &claude_dir);
 
     disable_raw_mode()?;
     if use_alt_screen {
@@ -105,6 +108,7 @@ fn run_app(
     app: &mut App,
     theme: &Theme,
     use_alt_screen: bool,
+    claude_dir: &std::path::Path,
 ) -> io::Result<()> {
     loop {
         terminal.draw(|frame| ui::render(frame, app, theme))?;
@@ -113,6 +117,22 @@ fn run_app(
             && let crossterm::event::Event::Key(key) = crossterm::event::read()?
         {
             app.handle_key(key);
+        }
+
+        // Periodic Sessions refresh
+        if !app.skip_real_refresh
+            && app.mode == app::AppMode::Sessions
+            && app.last_refresh.elapsed() >= app.refresh_interval()
+        {
+            app.refresh_sessions(claude_dir);
+        }
+
+        // Consume wants_refresh flag
+        if app.wants_refresh {
+            app.wants_refresh = false;
+            if !app.skip_real_refresh {
+                app.refresh_sessions(claude_dir);
+            }
         }
 
         if app.wants_edit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod markdown;
 mod scan;
+mod sessions;
 mod theme;
 mod ui;
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -36,7 +36,7 @@ pub struct Project {
 /// 2. Split by `-` and greedy-match against filesystem to resolve literal dashes
 ///
 /// Returns `None` if the original project directory no longer exists on disk.
-fn decode_project_name(encoded: &str) -> Option<String> {
+pub(crate) fn decode_project_name(encoded: &str) -> Option<String> {
     // Step 1: `--` → `/_` (restores underscore-prefixed dirs like `_active`)
     let normalized = encoded.replace("--", "/_");
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -177,7 +177,7 @@ pub fn scan_claude_dir(claude_dir: &Path) -> Vec<Project> {
         .collect();
 
     // Sort projects alphabetically
-    project_entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    project_entries.sort_by_key(|a| a.name.to_lowercase());
 
     // Deduplicate: Claude Code has two encoding schemes (old: `_active`, new: `--active`)
     // Keep the more recently modified entry

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -73,6 +73,46 @@ pub fn middle_truncate(s: &str, max: usize) -> String {
     format!("{head}…{tail}")
 }
 
+pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
+    if entry.has_last_prompt {
+        return State::Stale;
+    }
+    let elapsed = (now - entry.last_activity).num_seconds();
+    if elapsed < 300 {
+        State::Active
+    } else if elapsed < 3600 {
+        State::Idle
+    } else {
+        State::Stale
+    }
+}
+
+pub fn cache_ttl_remaining_secs(entry: &SessionEntry, now: DateTime<Utc>) -> i64 {
+    let elapsed = (now - entry.last_activity).num_seconds();
+    (300 - elapsed).max(0)
+}
+
+pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
+    match sort {
+        SessionsSort::LastActivity => {
+            entries.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+        }
+        SessionsSort::CacheTtl => {
+            entries.sort_by_key(|e| cache_ttl_remaining_secs(e, now));
+        }
+        SessionsSort::Project => {
+            entries.sort_by(|a, b| {
+                a.project_name
+                    .to_lowercase()
+                    .cmp(&b.project_name.to_lowercase())
+            });
+        }
+        SessionsSort::Size => {
+            entries.sort_by(|a, b| b.file_size.cmp(&a.file_size));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +170,106 @@ mod tests {
     #[test]
     fn middle_truncate_respects_max() {
         assert_eq!(middle_truncate("my-very-long-project", 10), "my-v…ject");
+    }
+
+    fn make_entry(id: &str, last_activity: DateTime<Utc>, has_last_prompt: bool) -> SessionEntry {
+        SessionEntry {
+            session_id: id.to_string(),
+            short_id: short_id(id),
+            project_name: format!("proj-{id}"),
+            cwd: None,
+            transcript_path: PathBuf::from(format!("/tmp/{id}.jsonl")),
+            started_at: Some(last_activity),
+            last_activity,
+            permission_mode: Some("auto".to_string()),
+            has_last_prompt,
+            file_size: 1000,
+        }
+    }
+
+    #[test]
+    fn state_at_active_when_recent() {
+        let now = Utc::now();
+        let entry = make_entry("a", now - chrono::Duration::seconds(30), false);
+        assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn state_at_idle_when_medium() {
+        let now = Utc::now();
+        let entry = make_entry("b", now - chrono::Duration::minutes(10), false);
+        assert_eq!(state_at(&entry, now), State::Idle);
+    }
+
+    #[test]
+    fn state_at_stale_when_old() {
+        let now = Utc::now();
+        let entry = make_entry("c", now - chrono::Duration::hours(2), false);
+        assert_eq!(state_at(&entry, now), State::Stale);
+    }
+
+    #[test]
+    fn state_at_stale_when_last_prompt_present() {
+        let now = Utc::now();
+        let entry = make_entry("d", now - chrono::Duration::seconds(10), true);
+        assert_eq!(state_at(&entry, now), State::Stale);
+    }
+
+    #[test]
+    fn sort_by_last_activity_desc() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("old", now - chrono::Duration::minutes(10), false),
+            make_entry("new", now - chrono::Duration::seconds(5), false),
+            make_entry("mid", now - chrono::Duration::minutes(2), false),
+        ];
+        sort_entries(&mut entries, SessionsSort::LastActivity, now);
+        assert_eq!(entries[0].session_id, "new");
+        assert_eq!(entries[1].session_id, "mid");
+        assert_eq!(entries[2].session_id, "old");
+    }
+
+    #[test]
+    fn sort_by_cache_ttl_asc_expiring_first() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("fresh", now - chrono::Duration::seconds(10), false),
+            make_entry("expiring", now - chrono::Duration::seconds(270), false),
+            make_entry("middle", now - chrono::Duration::seconds(120), false),
+        ];
+        sort_entries(&mut entries, SessionsSort::CacheTtl, now);
+        assert_eq!(entries[0].session_id, "expiring");
+        assert_eq!(entries[1].session_id, "middle");
+        assert_eq!(entries[2].session_id, "fresh");
+    }
+
+    #[test]
+    fn sort_by_project_alphabetical() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("c", now, false),
+            make_entry("a", now, false),
+            make_entry("b", now, false),
+        ];
+        sort_entries(&mut entries, SessionsSort::Project, now);
+        assert_eq!(entries[0].session_id, "a");
+        assert_eq!(entries[2].session_id, "c");
+    }
+
+    #[test]
+    fn sort_by_size_desc() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("small", now, false),
+            make_entry("big", now, false),
+            make_entry("mid", now, false),
+        ];
+        entries[0].file_size = 100;
+        entries[1].file_size = 10_000;
+        entries[2].file_size = 1_000;
+        sort_entries(&mut entries, SessionsSort::Size, now);
+        assert_eq!(entries[0].session_id, "big");
+        assert_eq!(entries[1].session_id, "mid");
+        assert_eq!(entries[2].session_id, "small");
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
@@ -90,6 +91,58 @@ pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
 pub fn cache_ttl_remaining_secs(entry: &SessionEntry, now: DateTime<Utc>) -> i64 {
     let elapsed = (now - entry.last_activity).num_seconds();
     (300 - elapsed).max(0)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FirstRecord {
+    pub session_id: Option<String>,
+    pub permission_mode: Option<String>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub cwd: Option<String>,
+}
+
+pub fn parse_first_record<R: Read>(reader: R) -> FirstRecord {
+    let buf = BufReader::new(reader);
+    let mut out = FirstRecord::default();
+
+    for line in buf.lines().take(10).flatten() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if out.session_id.is_none()
+            && let Some(sid) = value.get("sessionId").and_then(|v| v.as_str())
+        {
+            out.session_id = Some(sid.to_string());
+        }
+        if out.permission_mode.is_none()
+            && value.get("type").and_then(|v| v.as_str()) == Some("permission-mode")
+            && let Some(mode) = value.get("permissionMode").and_then(|v| v.as_str())
+        {
+            out.permission_mode = Some(mode.to_string());
+        }
+        if out.started_at.is_none()
+            && let Some(ts) = value.get("timestamp").and_then(|v| v.as_str())
+            && let Ok(dt) = DateTime::parse_from_rfc3339(ts)
+        {
+            out.started_at = Some(dt.with_timezone(&Utc));
+        }
+        if out.cwd.is_none()
+            && let Some(cwd) = value.get("cwd").and_then(|v| v.as_str())
+        {
+            out.cwd = Some(cwd.to_string());
+        }
+        if out.session_id.is_some()
+            && out.permission_mode.is_some()
+            && out.started_at.is_some()
+            && out.cwd.is_some()
+        {
+            break;
+        }
+    }
+    out
 }
 
 pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
@@ -254,6 +307,57 @@ mod tests {
         sort_entries(&mut entries, SessionsSort::Project, now);
         assert_eq!(entries[0].session_id, "a");
         assert_eq!(entries[2].session_id, "c");
+    }
+
+    #[test]
+    fn parse_first_record_extracts_session_id_from_permission_mode() {
+        let content = r#"{"type":"permission-mode","permissionMode":"auto","sessionId":"676b2e79-2ee5-4a7b-8cd3-2a5034cac2e6"}"#;
+        let parsed = parse_first_record(content.as_bytes());
+        assert_eq!(
+            parsed.session_id.as_deref(),
+            Some("676b2e79-2ee5-4a7b-8cd3-2a5034cac2e6")
+        );
+        assert_eq!(parsed.permission_mode.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn parse_first_record_scans_past_file_history_snapshot() {
+        let content = concat!(
+            r#"{"type":"file-history-snapshot","entries":[]}"#,
+            "\n",
+            r#"{"type":"permission-mode","permissionMode":"default","sessionId":"abc123"}"#,
+            "\n",
+        );
+        let parsed = parse_first_record(content.as_bytes());
+        assert_eq!(parsed.session_id.as_deref(), Some("abc123"));
+        assert_eq!(parsed.permission_mode.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn parse_first_record_extracts_timestamp_and_cwd_from_user_record() {
+        let content = concat!(
+            r#"{"type":"permission-mode","permissionMode":"auto","sessionId":"x1"}"#,
+            "\n",
+            r#"{"type":"user","timestamp":"2026-04-19T06:26:01.121Z","cwd":"/Users/kim/proj","sessionId":"x1"}"#,
+            "\n",
+        );
+        let parsed = parse_first_record(content.as_bytes());
+        assert!(parsed.started_at.is_some());
+        assert_eq!(parsed.cwd.as_deref(), Some("/Users/kim/proj"));
+    }
+
+    #[test]
+    fn parse_first_record_returns_empty_on_invalid_json() {
+        let content = "not valid json\n";
+        let parsed = parse_first_record(content.as_bytes());
+        assert!(parsed.session_id.is_none());
+        assert!(parsed.permission_mode.is_none());
+    }
+
+    #[test]
+    fn parse_first_record_handles_empty_input() {
+        let parsed = parse_first_record(b"" as &[u8]);
+        assert!(parsed.session_id.is_none());
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -18,7 +18,7 @@ pub struct SessionEntry {
     pub started_at: Option<DateTime<Utc>>,
     pub last_activity: DateTime<Utc>,
     pub permission_mode: Option<String>,
-    pub has_last_prompt: bool,
+    pub has_termination_record: bool,
     pub file_size: u64,
 }
 
@@ -84,7 +84,7 @@ pub fn middle_truncate(s: &str, max: usize) -> String {
 pub const TTL_SECS: i64 = 300;
 
 pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
-    if entry.has_last_prompt {
+    if entry.has_termination_record {
         return State::Stale;
     }
     let elapsed = (now - entry.last_activity).num_seconds();
@@ -159,7 +159,7 @@ const TAIL_CHUNK_BYTES: u64 = 8192;
 #[derive(Debug, Default, Clone)]
 pub struct TailRecord {
     pub last_activity: Option<DateTime<Utc>>,
-    pub has_last_prompt: bool,
+    pub has_termination_record: bool,
 }
 
 pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
@@ -192,7 +192,7 @@ pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
             continue;
         };
         if value.get("type").and_then(|v| v.as_str()) == Some("last-prompt") {
-            out.has_last_prompt = true;
+            out.has_termination_record = true;
         }
         if let Some(ts) = value.get("timestamp").and_then(|v| v.as_str())
             && let Ok(dt) = DateTime::parse_from_rfc3339(ts)
@@ -313,13 +313,16 @@ fn parse_session(path: &Path) -> Option<SessionEntry> {
         started_at: first.started_at,
         last_activity,
         permission_mode: first.permission_mode,
-        has_last_prompt: tail.has_last_prompt,
+        has_termination_record: tail.has_termination_record,
         file_size: meta.len(),
     })
 }
 
-#[allow(dead_code)]
-pub fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
+/// One-shot scan helper. Equivalent to `SessionCache::new().refresh(dir).entries()`.
+/// Used by tests; application code goes through `App::refresh_sessions` so the
+/// cache is preserved across refreshes.
+#[cfg(test)]
+fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
     let mut cache = SessionCache::new();
     cache.refresh(claude_dir);
     cache.entries()
@@ -339,7 +342,7 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
                 started_at: Some(last_activity - chrono::Duration::minutes(15)),
                 last_activity,
                 permission_mode: Some(mode.to_string()),
-                has_last_prompt: last_prompt,
+                has_termination_record: last_prompt,
                 file_size: size,
             }
         };
@@ -473,7 +476,11 @@ mod tests {
         assert_eq!(middle_truncate("my-very-long-project", 10), "my-v…ject");
     }
 
-    fn make_entry(id: &str, last_activity: DateTime<Utc>, has_last_prompt: bool) -> SessionEntry {
+    fn make_entry(
+        id: &str,
+        last_activity: DateTime<Utc>,
+        has_termination_record: bool,
+    ) -> SessionEntry {
         SessionEntry {
             session_id: id.to_string(),
             short_id: short_id(id),
@@ -483,7 +490,7 @@ mod tests {
             started_at: Some(last_activity),
             last_activity,
             permission_mode: Some("auto".to_string()),
-            has_last_prompt,
+            has_termination_record,
             file_size: 1000,
         }
     }
@@ -513,6 +520,34 @@ mod tests {
     fn state_at_stale_when_last_prompt_present() {
         let now = Utc::now();
         let entry = make_entry("d", now - chrono::Duration::seconds(10), true);
+        assert_eq!(state_at(&entry, now), State::Stale);
+    }
+
+    #[test]
+    fn state_at_active_just_under_300s() {
+        let now = Utc::now();
+        let entry = make_entry("e", now - chrono::Duration::seconds(299), false);
+        assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn state_at_idle_at_exactly_300s() {
+        let now = Utc::now();
+        let entry = make_entry("f", now - chrono::Duration::seconds(300), false);
+        assert_eq!(state_at(&entry, now), State::Idle);
+    }
+
+    #[test]
+    fn state_at_idle_just_under_3600s() {
+        let now = Utc::now();
+        let entry = make_entry("g", now - chrono::Duration::seconds(3599), false);
+        assert_eq!(state_at(&entry, now), State::Idle);
+    }
+
+    #[test]
+    fn state_at_stale_at_exactly_3600s() {
+        let now = Utc::now();
+        let entry = make_entry("h", now - chrono::Duration::seconds(3600), false);
         assert_eq!(state_at(&entry, now), State::Stale);
     }
 
@@ -638,7 +673,7 @@ mod tests {
             parsed.last_activity.map(|d| d.to_rfc3339()),
             Some("2026-04-19T06:10:00+00:00".to_string())
         );
-        assert!(!parsed.has_last_prompt);
+        assert!(!parsed.has_termination_record);
     }
 
     #[test]
@@ -648,7 +683,7 @@ mod tests {
             r#"{"type":"last-prompt","timestamp":"2026-04-19T06:10:00Z","lastPrompt":"bye"}"#,
         ]);
         let parsed = parse_tail(file.path()).unwrap();
-        assert!(parsed.has_last_prompt);
+        assert!(parsed.has_termination_record);
     }
 
     #[test]
@@ -656,7 +691,7 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
         let parsed = parse_tail(file.path()).unwrap();
         assert!(parsed.last_activity.is_none());
-        assert!(!parsed.has_last_prompt);
+        assert!(!parsed.has_termination_record);
     }
 
     #[test]
@@ -687,7 +722,7 @@ mod tests {
         .unwrap();
         let parsed = parse_tail(f.path()).unwrap();
         assert!(
-            parsed.has_last_prompt,
+            parsed.has_termination_record,
             "last-prompt record at end of large file must be detected"
         );
         assert!(

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -29,18 +29,13 @@ pub enum State {
     Stale,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SessionsSort {
+    #[default]
     LastActivity,
     CacheTtl,
     Project,
     Size,
-}
-
-impl Default for SessionsSort {
-    fn default() -> Self {
-        Self::LastActivity
-    }
 }
 
 pub fn short_id(uuid: &str) -> String {
@@ -110,7 +105,7 @@ pub fn parse_first_record<R: Read>(reader: R) -> FirstRecord {
     let buf = BufReader::new(reader);
     let mut out = FirstRecord::default();
 
-    for line in buf.lines().take(10).flatten() {
+    for line in buf.lines().take(10).map_while(Result::ok) {
         if line.trim().is_empty() {
             continue;
         }
@@ -173,7 +168,7 @@ pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
     let mut out = TailRecord::default();
     let buf = BufReader::new(file);
 
-    for line in buf.lines().flatten() {
+    for line in buf.lines().map_while(Result::ok) {
         if line.trim().is_empty() {
             continue;
         }
@@ -307,6 +302,7 @@ fn parse_session(path: &Path) -> Option<SessionEntry> {
     })
 }
 
+#[allow(dead_code)]
 pub fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
     let mut cache = SessionCache::new();
     cache.refresh(claude_dir);

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -311,26 +311,22 @@ pub fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
 
 pub fn demo_sessions() -> Vec<SessionEntry> {
     let now = Utc::now();
-    let make = |id: &str,
-                project: &str,
-                secs_ago: i64,
-                last_prompt: bool,
-                size: u64,
-                mode: &str| {
-        let last_activity = now - chrono::Duration::seconds(secs_ago);
-        SessionEntry {
-            session_id: id.to_string(),
-            short_id: short_id(id),
-            project_name: project.to_string(),
-            cwd: Some(PathBuf::from(format!("/Users/demo/{project}"))),
-            transcript_path: PathBuf::from(format!("/tmp/duru-demo/{id}.jsonl")),
-            started_at: Some(last_activity - chrono::Duration::minutes(15)),
-            last_activity,
-            permission_mode: Some(mode.to_string()),
-            has_last_prompt: last_prompt,
-            file_size: size,
-        }
-    };
+    let make =
+        |id: &str, project: &str, secs_ago: i64, last_prompt: bool, size: u64, mode: &str| {
+            let last_activity = now - chrono::Duration::seconds(secs_ago);
+            SessionEntry {
+                session_id: id.to_string(),
+                short_id: short_id(id),
+                project_name: project.to_string(),
+                cwd: Some(PathBuf::from(format!("/Users/demo/{project}"))),
+                transcript_path: PathBuf::from(format!("/tmp/duru-demo/{id}.jsonl")),
+                started_at: Some(last_activity - chrono::Duration::minutes(15)),
+                last_activity,
+                permission_mode: Some(mode.to_string()),
+                has_last_prompt: last_prompt,
+                file_size: size,
+            }
+        };
     vec![
         make(
             "676b2e79-2ee5-4a7b-8cd3-2a5034cac2e6",
@@ -604,10 +600,7 @@ mod tests {
         cache.refresh(tmp.path());
         assert!(
             cache.entries().len() < initial_count
-                || !cache
-                    .entries()
-                    .iter()
-                    .any(|e| e.transcript_path == jsonl)
+                || !cache.entries().iter().any(|e| e.transcript_path == jsonl)
         );
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -313,6 +313,72 @@ pub fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
     cache.entries()
 }
 
+pub fn demo_sessions() -> Vec<SessionEntry> {
+    let now = Utc::now();
+    let make = |id: &str,
+                project: &str,
+                secs_ago: i64,
+                last_prompt: bool,
+                size: u64,
+                mode: &str| {
+        let last_activity = now - chrono::Duration::seconds(secs_ago);
+        SessionEntry {
+            session_id: id.to_string(),
+            short_id: short_id(id),
+            project_name: project.to_string(),
+            cwd: Some(PathBuf::from(format!("/Users/demo/{project}"))),
+            transcript_path: PathBuf::from(format!("/tmp/duru-demo/{id}.jsonl")),
+            started_at: Some(last_activity - chrono::Duration::minutes(15)),
+            last_activity,
+            permission_mode: Some(mode.to_string()),
+            has_last_prompt: last_prompt,
+            file_size: size,
+        }
+    };
+    vec![
+        make(
+            "676b2e79-2ee5-4a7b-8cd3-2a5034cac2e6",
+            "my-webapp",
+            12,
+            false,
+            234_000,
+            "auto",
+        ),
+        make(
+            "a3f1e2d4-1234-1234-1234-123456789abc",
+            "duru",
+            120,
+            false,
+            187_000,
+            "auto",
+        ),
+        make(
+            "b9e73dca-aefb-4a83-88f8-4534127e6281",
+            "namuldogam",
+            240,
+            false,
+            92_000,
+            "default",
+        ),
+        make(
+            "90515568-bd14-4207-a9f5-2bc9d59973e7",
+            "chrome-secret",
+            1080,
+            false,
+            412_000,
+            "auto",
+        ),
+        make(
+            "f3bc49c4-5db3-4e09-8f60-de8c87654f6b",
+            "rust-playground",
+            3600,
+            true,
+            1_200_000,
+            "default",
+        ),
+    ]
+}
+
 pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
     match sort {
         SessionsSort::LastActivity => {
@@ -488,6 +554,13 @@ mod tests {
     }
 
     use std::fs;
+
+    #[test]
+    fn demo_sessions_returns_five_entries() {
+        let demos = demo_sessions();
+        assert_eq!(demos.len(), 5);
+        assert!(demos.iter().any(|e| e.project_name == "my-webapp"));
+    }
 
     #[test]
     fn scan_empty_claude_dir_returns_empty() {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,8 +1,12 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
+
+use crate::scan::decode_project_name;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionEntry {
@@ -192,6 +196,123 @@ pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
     Ok(out)
 }
 
+#[derive(Debug, Default)]
+pub struct SessionCache {
+    by_path: HashMap<PathBuf, (SessionEntry, SystemTime)>,
+}
+
+impl SessionCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn entries(&self) -> Vec<SessionEntry> {
+        self.by_path.values().map(|(e, _)| e.clone()).collect()
+    }
+
+    pub fn refresh(&mut self, claude_dir: &Path) {
+        let found = walk_session_files(claude_dir);
+        let found_paths: std::collections::HashSet<PathBuf> =
+            found.iter().map(|(p, _)| p.clone()).collect();
+
+        self.by_path.retain(|path, _| found_paths.contains(path));
+
+        for (path, mtime) in found {
+            let needs_reparse = match self.by_path.get(&path) {
+                Some((_, prev_mtime)) => *prev_mtime != mtime,
+                None => true,
+            };
+            if !needs_reparse {
+                continue;
+            }
+            if let Some(entry) = parse_session(&path) {
+                self.by_path.insert(path.clone(), (entry, mtime));
+            }
+        }
+    }
+}
+
+fn walk_session_files(claude_dir: &Path) -> Vec<(PathBuf, SystemTime)> {
+    let mut out = Vec::new();
+    let projects_dir = claude_dir.join("projects");
+    let Ok(project_iter) = std::fs::read_dir(&projects_dir) else {
+        return out;
+    };
+    for project_entry in project_iter.flatten() {
+        let project_path = project_entry.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let Ok(file_iter) = std::fs::read_dir(&project_path) else {
+            continue;
+        };
+        for file_entry in file_iter.flatten() {
+            let path = file_entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if fname == "skill-injections.jsonl" {
+                continue;
+            }
+            if !fname.ends_with(".jsonl") {
+                continue;
+            }
+            let Ok(meta) = path.metadata() else { continue };
+            let Ok(mtime) = meta.modified() else { continue };
+            out.push((path, mtime));
+        }
+    }
+    out
+}
+
+fn parse_session(path: &Path) -> Option<SessionEntry> {
+    let meta = path.metadata().ok()?;
+    let mtime_sys = meta.modified().ok()?;
+    let mtime = DateTime::<Utc>::from(mtime_sys);
+
+    let file = File::open(path).ok()?;
+    let first = parse_first_record(file);
+    let tail = parse_tail(path).ok()?;
+
+    let filename_uuid = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    let session_id = first.session_id.unwrap_or_else(|| filename_uuid.clone());
+    let short = short_id(&session_id);
+
+    let project_dir_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string();
+    let project_name = decode_project_name(&project_dir_name).unwrap_or(project_dir_name);
+
+    let last_activity = tail.last_activity.unwrap_or(mtime);
+
+    Some(SessionEntry {
+        session_id,
+        short_id: short,
+        project_name,
+        cwd: first.cwd.map(PathBuf::from),
+        transcript_path: path.to_path_buf(),
+        started_at: first.started_at,
+        last_activity,
+        permission_mode: first.permission_mode,
+        has_last_prompt: tail.has_last_prompt,
+        file_size: meta.len(),
+    })
+}
+
+pub fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
+    let mut cache = SessionCache::new();
+    cache.refresh(claude_dir);
+    cache.entries()
+}
+
 pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
     match sort {
         SessionsSort::LastActivity => {
@@ -364,6 +485,61 @@ mod tests {
             writeln!(f, "{line}").unwrap();
         }
         f
+    }
+
+    use std::fs;
+
+    #[test]
+    fn scan_empty_claude_dir_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entries = scan_sessions(tmp.path());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn scan_skips_skill_injections_jsonl() {
+        let tmp = tempfile::tempdir().unwrap();
+        let encoded = tmp.path().join("projects").join("-Users-fake-realproj");
+        fs::create_dir_all(&encoded).unwrap();
+        fs::write(encoded.join("skill-injections.jsonl"), "").unwrap();
+        let entries = scan_sessions(tmp.path());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn cache_refresh_on_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cache = SessionCache::new();
+        cache.refresh(tmp.path());
+        assert!(cache.entries().is_empty());
+        cache.refresh(tmp.path());
+        assert!(cache.entries().is_empty());
+    }
+
+    #[test]
+    fn cache_removes_deleted_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("projects").join("-x");
+        fs::create_dir_all(&proj).unwrap();
+        let jsonl = proj.join("zzzz1234-zzzz-zzzz-zzzz-zzzzzzzzzzzz.jsonl");
+        fs::write(
+            &jsonl,
+            r#"{"type":"user","timestamp":"2026-04-19T06:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let mut cache = SessionCache::new();
+        cache.refresh(tmp.path());
+        let initial_count = cache.entries().len();
+        fs::remove_file(&jsonl).unwrap();
+        cache.refresh(tmp.path());
+        assert!(
+            cache.entries().len() < initial_count
+                || !cache
+                    .entries()
+                    .iter()
+                    .any(|e| e.transcript_path == jsonl)
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -374,20 +374,16 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
 pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
     match sort {
         SessionsSort::LastActivity => {
-            entries.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+            entries.sort_by_key(|e| std::cmp::Reverse(e.last_activity));
         }
         SessionsSort::CacheTtl => {
             entries.sort_by_key(|e| cache_ttl_remaining_secs(e, now));
         }
         SessionsSort::Project => {
-            entries.sort_by(|a, b| {
-                a.project_name
-                    .to_lowercase()
-                    .cmp(&b.project_name.to_lowercase())
-            });
+            entries.sort_by_key(|e| e.project_name.to_lowercase());
         }
         SessionsSort::Size => {
-            entries.sort_by(|a, b| b.file_size.cmp(&a.file_size));
+            entries.sort_by_key(|e| std::cmp::Reverse(e.file_size));
         }
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -53,12 +53,14 @@ pub fn format_duration(secs: i64) -> String {
 }
 
 pub fn format_bytes(bytes: u64) -> String {
+    // Binary units (K = 1024, M = 1024²) to match ui::format_size so a file
+    // shown in both Memory and Sessions modes displays the same size.
     if bytes < 1024 {
         format!("{}B", bytes)
-    } else if bytes < 1_000_000 {
-        format!("{}K", bytes / 1000)
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1}K", bytes as f64 / 1024.0)
     } else {
-        format!("{:.1}M", bytes as f64 / 1_000_000.0)
+        format!("{:.1}M", bytes as f64 / (1024.0 * 1024.0))
     }
 }
 
@@ -74,12 +76,19 @@ pub fn middle_truncate(s: &str, max: usize) -> String {
     format!("{head}…{tail}")
 }
 
+/// Anthropic's default prompt cache TTL in seconds (5 minutes).
+///
+/// This is the canonical source; `ui::render_ttl_cell` imports it for the
+/// progress-bar denominator. The `State::Active` window is aligned with this
+/// value so "Active" visually signals "cache likely still warm".
+pub const TTL_SECS: i64 = 300;
+
 pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
     if entry.has_last_prompt {
         return State::Stale;
     }
     let elapsed = (now - entry.last_activity).num_seconds();
-    if elapsed < 300 {
+    if elapsed < TTL_SECS {
         State::Active
     } else if elapsed < 3600 {
         State::Idle
@@ -90,7 +99,7 @@ pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
 
 pub fn cache_ttl_remaining_secs(entry: &SessionEntry, now: DateTime<Utc>) -> i64 {
     let elapsed = (now - entry.last_activity).num_seconds();
-    (300 - elapsed).max(0)
+    (TTL_SECS - elapsed).max(0)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -431,17 +440,27 @@ mod tests {
 
     #[test]
     fn format_bytes_kilobytes() {
-        assert_eq!(format_bytes(180_000), "180K");
+        // 180_000 / 1024 = 175.781… → "175.8K" (binary units match ui::format_size)
+        assert_eq!(format_bytes(180_000), "175.8K");
     }
 
     #[test]
     fn format_bytes_megabytes() {
-        assert_eq!(format_bytes(1_200_000), "1.2M");
+        // 1_200_000 / (1024 × 1024) = 1.144… → "1.1M"
+        assert_eq!(format_bytes(1_200_000), "1.1M");
     }
 
     #[test]
     fn format_bytes_under_1k() {
         assert_eq!(format_bytes(512), "512B");
+    }
+
+    #[test]
+    fn format_bytes_matches_ui_format_size_conventions() {
+        // Both functions must agree on binary units so the same file shows
+        // the same size across Memory and Sessions modes.
+        assert_eq!(format_bytes(2048), "2.0K");
+        assert_eq!(format_bytes(1_048_576), "1.0M");
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,0 +1,38 @@
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEntry {
+    pub session_id: String,
+    pub short_id: String,
+    pub project_name: String,
+    pub cwd: Option<PathBuf>,
+    pub transcript_path: PathBuf,
+    pub started_at: Option<DateTime<Utc>>,
+    pub last_activity: DateTime<Utc>,
+    pub permission_mode: Option<String>,
+    pub has_last_prompt: bool,
+    pub file_size: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    Active,
+    Idle,
+    Stale,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionsSort {
+    LastActivity,
+    CacheTtl,
+    Project,
+    Size,
+}
+
+impl Default for SessionsSort {
+    fn default() -> Self {
+        Self::LastActivity
+    }
+}

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,5 +1,6 @@
-use std::io::{BufRead, BufReader, Read};
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 
@@ -143,6 +144,52 @@ pub fn parse_first_record<R: Read>(reader: R) -> FirstRecord {
         }
     }
     out
+}
+
+const TAIL_CHUNK_BYTES: u64 = 8192;
+
+#[derive(Debug, Default, Clone)]
+pub struct TailRecord {
+    pub last_activity: Option<DateTime<Utc>>,
+    pub has_last_prompt: bool,
+}
+
+pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
+    let mut file = File::open(path)?;
+    let file_len = file.metadata()?.len();
+
+    if file_len > TAIL_CHUNK_BYTES {
+        file.seek(SeekFrom::End(-(TAIL_CHUNK_BYTES as i64)))?;
+        // Drop potentially-partial first line after seek
+        let mut discard = String::new();
+        let mut reader = BufReader::new(&mut file);
+        let _ = reader.read_line(&mut discard);
+    }
+
+    let mut out = TailRecord::default();
+    let buf = BufReader::new(file);
+
+    for line in buf.lines().flatten() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if value.get("type").and_then(|v| v.as_str()) == Some("last-prompt") {
+            out.has_last_prompt = true;
+        }
+        if let Some(ts) = value.get("timestamp").and_then(|v| v.as_str())
+            && let Ok(dt) = DateTime::parse_from_rfc3339(ts)
+        {
+            let dt_utc = dt.with_timezone(&Utc);
+            out.last_activity = Some(match out.last_activity {
+                Some(prev) if prev > dt_utc => prev,
+                _ => dt_utc,
+            });
+        }
+    }
+    Ok(out)
 }
 
 pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
@@ -307,6 +354,59 @@ mod tests {
         sort_entries(&mut entries, SessionsSort::Project, now);
         assert_eq!(entries[0].session_id, "a");
         assert_eq!(entries[2].session_id, "c");
+    }
+
+    use std::io::Write;
+
+    fn tempfile_with(lines: &[&str]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        for line in lines {
+            writeln!(f, "{line}").unwrap();
+        }
+        f
+    }
+
+    #[test]
+    fn parse_tail_finds_last_timestamp() {
+        let file = tempfile_with(&[
+            r#"{"type":"user","timestamp":"2026-04-19T06:00:00Z","sessionId":"x"}"#,
+            r#"{"type":"assistant","timestamp":"2026-04-19T06:05:00Z","sessionId":"x"}"#,
+            r#"{"type":"user","timestamp":"2026-04-19T06:10:00Z","sessionId":"x"}"#,
+        ]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert_eq!(
+            parsed.last_activity.map(|d| d.to_rfc3339()),
+            Some("2026-04-19T06:10:00+00:00".to_string())
+        );
+        assert!(!parsed.has_last_prompt);
+    }
+
+    #[test]
+    fn parse_tail_detects_last_prompt_record() {
+        let file = tempfile_with(&[
+            r#"{"type":"user","timestamp":"2026-04-19T06:00:00Z","sessionId":"x"}"#,
+            r#"{"type":"last-prompt","timestamp":"2026-04-19T06:10:00Z","lastPrompt":"bye"}"#,
+        ]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert!(parsed.has_last_prompt);
+    }
+
+    #[test]
+    fn parse_tail_handles_empty_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let parsed = parse_tail(file.path()).unwrap();
+        assert!(parsed.last_activity.is_none());
+        assert!(!parsed.has_last_prompt);
+    }
+
+    #[test]
+    fn parse_tail_ignores_invalid_json_lines() {
+        let file = tempfile_with(&[
+            r#"not valid json"#,
+            r#"{"type":"user","timestamp":"2026-04-19T06:00:00Z"}"#,
+        ]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert!(parsed.last_activity.is_some());
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -156,19 +156,26 @@ pub struct TailRecord {
 pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
     let mut file = File::open(path)?;
     let file_len = file.metadata()?.len();
+    let skip_first = file_len > TAIL_CHUNK_BYTES;
 
-    if file_len > TAIL_CHUNK_BYTES {
+    if skip_first {
         file.seek(SeekFrom::End(-(TAIL_CHUNK_BYTES as i64)))?;
-        // Drop potentially-partial first line after seek
-        let mut discard = String::new();
-        let mut reader = BufReader::new(&mut file);
-        let _ = reader.read_line(&mut discard);
     }
 
     let mut out = TailRecord::default();
-    let buf = BufReader::new(file);
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines().map_while(Result::ok);
 
-    for line in buf.lines().map_while(Result::ok) {
+    // When we seeked into the middle of the file, the first line is likely a
+    // partial record — discard it. Using a single BufReader here is critical:
+    // `BufReader::new(&mut file)` would fill its internal 8 KiB buffer in one
+    // `read()` syscall, advancing the OS file position to EOF; a subsequent
+    // BufReader on the same file would then read nothing. See PR #8 review.
+    if skip_first {
+        lines.next();
+    }
+
+    for line in lines {
         if line.trim().is_empty() {
             continue;
         }
@@ -641,6 +648,33 @@ mod tests {
         ]);
         let parsed = parse_tail(file.path()).unwrap();
         assert!(parsed.last_activity.is_some());
+    }
+
+    #[test]
+    fn parse_tail_reads_tail_of_large_file() {
+        // Regression test for PR #8 double-BufReader bug: when file exceeds
+        // TAIL_CHUNK_BYTES (8 KiB), the old impl read nothing because the
+        // first BufReader drained the file to EOF.
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        // Write ~9 KiB of noise lines (200 × ~47 bytes each), then a
+        // last-prompt record at the very end.
+        for _ in 0..200 {
+            writeln!(f, "{}", "x".repeat(46)).unwrap();
+        }
+        writeln!(
+            f,
+            r#"{{"type":"last-prompt","timestamp":"2026-04-19T08:00:00Z","lastPrompt":"bye"}}"#
+        )
+        .unwrap();
+        let parsed = parse_tail(f.path()).unwrap();
+        assert!(
+            parsed.has_last_prompt,
+            "last-prompt record at end of large file must be detected"
+        );
+        assert!(
+            parsed.last_activity.is_some(),
+            "last_activity must be parsed from the tail even for large files"
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -36,3 +36,99 @@ impl Default for SessionsSort {
         Self::LastActivity
     }
 }
+
+pub fn short_id(uuid: &str) -> String {
+    uuid.chars().take(8).collect()
+}
+
+pub fn format_duration(secs: i64) -> String {
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h", secs / 3600)
+    }
+}
+
+pub fn format_bytes(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{}B", bytes)
+    } else if bytes < 1_000_000 {
+        format!("{}K", bytes / 1000)
+    } else {
+        format!("{:.1}M", bytes as f64 / 1_000_000.0)
+    }
+}
+
+pub fn middle_truncate(s: &str, max: usize) -> String {
+    let count = s.chars().count();
+    if count <= max {
+        return s.to_string();
+    }
+    let keep = max.saturating_sub(1) / 2;
+    let chars: Vec<char> = s.chars().collect();
+    let head: String = chars.iter().take(keep).collect();
+    let tail: String = chars[count - keep..].iter().collect();
+    format!("{head}…{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_takes_first_8_chars() {
+        assert_eq!(short_id("676b2e79-2ee5-4a7b-8cd3-2a5034cac2e6"), "676b2e79");
+    }
+
+    #[test]
+    fn short_id_pads_when_input_shorter_than_8() {
+        assert_eq!(short_id("abc"), "abc");
+    }
+
+    #[test]
+    fn format_duration_sec() {
+        assert_eq!(format_duration(12), "12s");
+    }
+
+    #[test]
+    fn format_duration_min() {
+        assert_eq!(format_duration(180), "3m");
+    }
+
+    #[test]
+    fn format_duration_hour() {
+        assert_eq!(format_duration(3700), "1h");
+    }
+
+    #[test]
+    fn format_duration_zero() {
+        assert_eq!(format_duration(0), "0s");
+    }
+
+    #[test]
+    fn format_bytes_kilobytes() {
+        assert_eq!(format_bytes(180_000), "180K");
+    }
+
+    #[test]
+    fn format_bytes_megabytes() {
+        assert_eq!(format_bytes(1_200_000), "1.2M");
+    }
+
+    #[test]
+    fn format_bytes_under_1k() {
+        assert_eq!(format_bytes(512), "512B");
+    }
+
+    #[test]
+    fn middle_truncate_leaves_short_string() {
+        assert_eq!(middle_truncate("short", 10), "short");
+    }
+
+    #[test]
+    fn middle_truncate_respects_max() {
+        assert_eq!(middle_truncate("my-very-long-project", 10), "my-v…ject");
+    }
+}

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -113,7 +113,7 @@ pub fn middle_truncate(s: &str, max: usize) -> String {
 pub const TTL_SECS: i64 = 300;
 
 /// Boundary between `State::Idle` and `State::Stale` (1 hour).
-pub const IDLE_CUTOFF_SECS: i64 = 3600;
+pub(crate) const IDLE_CUTOFF_SECS: i64 = 3600;
 
 /// First N lines of a transcript scanned to extract session_id / permission /
 /// started_at / cwd. Enough to skip past `file-history-snapshot` records

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -9,6 +9,35 @@ use chrono::{DateTime, Utc};
 use crate::scan::decode_project_name;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionMode {
+    Auto,
+    Default,
+    AcceptEdits,
+    Other(String),
+}
+
+impl PermissionMode {
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "auto" => Self::Auto,
+            "default" => Self::Default,
+            "acceptEdits" => Self::AcceptEdits,
+            other => Self::Other(other.to_string()),
+        }
+    }
+
+    /// Short label for the Sessions-table `Mode` column (max 7 chars).
+    pub fn abbrev(&self) -> &str {
+        match self {
+            Self::Auto => "auto",
+            Self::Default => "default",
+            Self::AcceptEdits => "accept",
+            Self::Other(_) => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionEntry {
     pub session_id: String,
     pub short_id: String,
@@ -17,7 +46,7 @@ pub struct SessionEntry {
     pub transcript_path: PathBuf,
     pub started_at: Option<DateTime<Utc>>,
     pub last_activity: DateTime<Utc>,
-    pub permission_mode: Option<String>,
+    pub permission_mode: Option<PermissionMode>,
     pub has_termination_record: bool,
     pub file_size: u64,
 }
@@ -39,7 +68,7 @@ pub enum SessionsSort {
 }
 
 pub fn short_id(uuid: &str) -> String {
-    uuid.chars().take(8).collect()
+    uuid.chars().take(SHORT_ID_LEN).collect()
 }
 
 pub fn format_duration(secs: i64) -> String {
@@ -78,10 +107,21 @@ pub fn middle_truncate(s: &str, max: usize) -> String {
 
 /// Anthropic's default prompt cache TTL in seconds (5 minutes).
 ///
-/// This is the canonical source; `ui::render_ttl_cell` imports it for the
-/// progress-bar denominator. The `State::Active` window is aligned with this
-/// value so "Active" visually signals "cache likely still warm".
+/// Canonical source; `ui::render_ttl_cell` imports it as the bar denominator.
+/// The `State::Active` window is aligned with this value so "Active" visually
+/// signals "cache likely still warm".
 pub const TTL_SECS: i64 = 300;
+
+/// Boundary between `State::Idle` and `State::Stale` (1 hour).
+pub const IDLE_CUTOFF_SECS: i64 = 3600;
+
+/// First N lines of a transcript scanned to extract session_id / permission /
+/// started_at / cwd. Enough to skip past `file-history-snapshot` records
+/// that sometimes precede the `permission-mode` row.
+const FIRST_RECORD_SCAN_LINES: usize = 10;
+
+/// Short-form session ID length (first N chars of the UUID).
+const SHORT_ID_LEN: usize = 8;
 
 pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
     if entry.has_termination_record {
@@ -90,7 +130,7 @@ pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
     let elapsed = (now - entry.last_activity).num_seconds();
     if elapsed < TTL_SECS {
         State::Active
-    } else if elapsed < 3600 {
+    } else if elapsed < IDLE_CUTOFF_SECS {
         State::Idle
     } else {
         State::Stale
@@ -105,7 +145,7 @@ pub fn cache_ttl_remaining_secs(entry: &SessionEntry, now: DateTime<Utc>) -> i64
 #[derive(Debug, Default, Clone)]
 pub struct FirstRecord {
     pub session_id: Option<String>,
-    pub permission_mode: Option<String>,
+    pub permission_mode: Option<PermissionMode>,
     pub started_at: Option<DateTime<Utc>>,
     pub cwd: Option<String>,
 }
@@ -114,7 +154,11 @@ pub fn parse_first_record<R: Read>(reader: R) -> FirstRecord {
     let buf = BufReader::new(reader);
     let mut out = FirstRecord::default();
 
-    for line in buf.lines().take(10).map_while(Result::ok) {
+    for line in buf
+        .lines()
+        .take(FIRST_RECORD_SCAN_LINES)
+        .map_while(Result::ok)
+    {
         if line.trim().is_empty() {
             continue;
         }
@@ -130,7 +174,7 @@ pub fn parse_first_record<R: Read>(reader: R) -> FirstRecord {
             && value.get("type").and_then(|v| v.as_str()) == Some("permission-mode")
             && let Some(mode) = value.get("permissionMode").and_then(|v| v.as_str())
         {
-            out.permission_mode = Some(mode.to_string());
+            out.permission_mode = Some(PermissionMode::parse(mode));
         }
         if out.started_at.is_none()
             && let Some(ts) = value.get("timestamp").and_then(|v| v.as_str())
@@ -175,13 +219,12 @@ pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
     let reader = BufReader::new(file);
     let mut lines = reader.lines().map_while(Result::ok);
 
-    // When we seeked into the middle of the file, the first line is likely a
-    // partial record — discard it. Using a single BufReader here is critical:
-    // `BufReader::new(&mut file)` would fill its internal 8 KiB buffer in one
-    // `read()` syscall, advancing the OS file position to EOF; a subsequent
-    // BufReader on the same file would then read nothing. See PR #8 review.
+    // Single BufReader is required: a second BufReader on the same File would
+    // share the OS file offset. The first fill_buf drains up to 8 KiB in one
+    // read() syscall, leaving the offset at EOF; a fresh BufReader would then
+    // yield nothing.
     if skip_first {
-        lines.next();
+        lines.next(); // potentially-partial first line from mid-file seek
     }
 
     for line in lines {
@@ -341,7 +384,7 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
                 transcript_path: PathBuf::from(format!("/tmp/duru-demo/{id}.jsonl")),
                 started_at: Some(last_activity - chrono::Duration::minutes(15)),
                 last_activity,
-                permission_mode: Some(mode.to_string()),
+                permission_mode: Some(PermissionMode::parse(mode)),
                 has_termination_record: last_prompt,
                 file_size: size,
             }
@@ -492,7 +535,7 @@ mod tests {
             transcript_path: PathBuf::from(format!("/tmp/{id}.jsonl")),
             started_at: Some(last_activity),
             last_activity,
-            permission_mode: Some("auto".to_string()),
+            permission_mode: Some(PermissionMode::Auto),
             has_termination_record,
             file_size: 1000,
         }
@@ -742,7 +785,7 @@ mod tests {
             parsed.session_id.as_deref(),
             Some("676b2e79-2ee5-4a7b-8cd3-2a5034cac2e6")
         );
-        assert_eq!(parsed.permission_mode.as_deref(), Some("auto"));
+        assert_eq!(parsed.permission_mode, Some(PermissionMode::Auto));
     }
 
     #[test]
@@ -755,7 +798,7 @@ mod tests {
         );
         let parsed = parse_first_record(content.as_bytes());
         assert_eq!(parsed.session_id.as_deref(), Some("abc123"));
-        assert_eq!(parsed.permission_mode.as_deref(), Some("default"));
+        assert_eq!(parsed.permission_mode, Some(PermissionMode::Default));
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -396,6 +396,9 @@ pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateT
             entries.sort_by_key(|e| std::cmp::Reverse(e.last_activity));
         }
         SessionsSort::CacheTtl => {
+            // Ascending on purpose: sessions closest to expiry come first
+            // ("needs attention" order). Do not "fix" to Reverse — that
+            // would hide the sessions a user cares most about at the bottom.
             entries.sort_by_key(|e| cache_ttl_remaining_secs(e, now));
         }
         SessionsSort::Project => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,10 +72,7 @@ fn mode_abbrev(mode: Option<&str>) -> &'static str {
     }
 }
 
-fn relative_age(
-    last: chrono::DateTime<chrono::Utc>,
-    now: chrono::DateTime<chrono::Utc>,
-) -> String {
+fn relative_age(last: chrono::DateTime<chrono::Utc>, now: chrono::DateTime<chrono::Utc>) -> String {
     let elapsed = (now - last).num_seconds().max(0);
     sessions::format_duration(elapsed)
 }
@@ -131,10 +128,7 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
             let project = sessions::middle_truncate(&entry.project_name, 22);
 
             Row::new(vec![
-                Cell::from(Line::from(vec![
-                    Span::raw(" "),
-                    state_glyph(state, theme),
-                ])),
+                Cell::from(Line::from(vec![Span::raw(" "), state_glyph(state, theme)])),
                 Cell::from(entry.short_id.clone()),
                 Cell::from(project),
                 Cell::from(mode_abbrev(entry.permission_mode.as_deref())),
@@ -171,8 +165,7 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
 
     let mut state = TableState::default();
     state.select(Some(
-        app.session_index
-            .min(app.sessions.len().saturating_sub(1)),
+        app.session_index.min(app.sessions.len().saturating_sub(1)),
     ));
     frame.render_stateful_widget(table, area, &mut state);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,28 +6,68 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Wrap},
 };
 
-use crate::app::{App, Pane};
+use crate::app::{App, AppMode, Pane};
 use crate::markdown;
 use crate::theme::Theme;
 
 pub fn render(frame: &mut Frame, app: &App, theme: &Theme) {
     let area = frame.area();
 
-    // Main area + 1-line help bar
-    let outer = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
+    // Layout: tab bar (1) / body (flex) / help bar (1)
+    let outer = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
 
-    // 3-pane layout: 30% | 30% | 40%
+    render_tab_bar(frame, app.mode, theme, outer[0]);
+
+    match app.mode {
+        AppMode::Memory => render_memory_layout(frame, app, theme, outer[1]),
+        AppMode::Sessions => render_sessions_layout(frame, app, theme, outer[1]),
+    }
+
+    render_help_bar(frame, app.mode, theme, outer[2]);
+}
+
+fn render_memory_layout(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     let chunks = Layout::horizontal([
         Constraint::Percentage(30),
         Constraint::Percentage(30),
         Constraint::Percentage(40),
     ])
-    .split(outer[0]);
+    .split(area);
 
     render_projects_pane(frame, app, theme, chunks[0]);
     render_files_pane(frame, app, theme, chunks[1]);
     render_preview_pane(frame, app, theme, chunks[2]);
-    render_help_bar(frame, theme, outer[1]);
+}
+
+fn render_sessions_layout(_frame: &mut Frame, _app: &App, _theme: &Theme, _area: Rect) {
+    // Implemented in Task 16
+}
+
+fn render_tab_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) {
+    let style_active = Style::default().fg(theme.iris).add_modifier(Modifier::BOLD);
+    let style_muted = Style::default().fg(theme.muted);
+
+    let (mem_style, ses_style) = match mode {
+        AppMode::Memory => (style_active, style_muted),
+        AppMode::Sessions => (style_muted, style_active),
+    };
+
+    let line = Line::from(vec![
+        Span::styled("  Memory  ", mem_style),
+        Span::styled("│", Style::default().fg(theme.overlay)),
+        Span::styled("  Sessions  ", ses_style),
+        Span::styled("   (Tab to switch)", Style::default().fg(theme.overlay)),
+    ]);
+
+    frame.render_widget(
+        Paragraph::new(line).style(Style::default().bg(theme.surface)),
+        area,
+    );
 }
 
 fn pane_block<'a>(title: &'a str, focused: bool, theme: &'a Theme) -> Block<'a> {
@@ -138,17 +178,35 @@ fn render_preview_pane(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
     frame.render_widget(paragraph, area);
 }
 
-fn render_help_bar(frame: &mut Frame, theme: &Theme, area: Rect) {
-    let help = Line::from(vec![
-        Span::styled(" ↑↓", Style::default().fg(theme.text)),
-        Span::styled(" navigate  ", Style::default().fg(theme.muted)),
-        Span::styled("←→", Style::default().fg(theme.text)),
-        Span::styled(" pane  ", Style::default().fg(theme.muted)),
-        Span::styled("e", Style::default().fg(theme.text)),
-        Span::styled(" edit  ", Style::default().fg(theme.muted)),
-        Span::styled("q", Style::default().fg(theme.text)),
-        Span::styled(" quit", Style::default().fg(theme.muted)),
-    ]);
+fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) {
+    let help = match mode {
+        AppMode::Memory => Line::from(vec![
+            Span::styled(" ↑↓", Style::default().fg(theme.text)),
+            Span::styled(" navigate  ", Style::default().fg(theme.muted)),
+            Span::styled("←→", Style::default().fg(theme.text)),
+            Span::styled(" pane  ", Style::default().fg(theme.muted)),
+            Span::styled("e", Style::default().fg(theme.text)),
+            Span::styled(" edit  ", Style::default().fg(theme.muted)),
+            Span::styled("Tab", Style::default().fg(theme.text)),
+            Span::styled(" sessions  ", Style::default().fg(theme.muted)),
+            Span::styled("q", Style::default().fg(theme.text)),
+            Span::styled(" quit", Style::default().fg(theme.muted)),
+        ]),
+        AppMode::Sessions => Line::from(vec![
+            Span::styled(" ↑↓", Style::default().fg(theme.text)),
+            Span::styled(" navigate  ", Style::default().fg(theme.muted)),
+            Span::styled("←→", Style::default().fg(theme.text)),
+            Span::styled(" pane  ", Style::default().fg(theme.muted)),
+            Span::styled("s", Style::default().fg(theme.text)),
+            Span::styled(" sort  ", Style::default().fg(theme.muted)),
+            Span::styled("r", Style::default().fg(theme.text)),
+            Span::styled(" refresh  ", Style::default().fg(theme.muted)),
+            Span::styled("Tab", Style::default().fg(theme.text)),
+            Span::styled(" memory  ", Style::default().fg(theme.muted)),
+            Span::styled("q", Style::default().fg(theme.text)),
+            Span::styled(" quit", Style::default().fg(theme.muted)),
+        ]),
+    };
     frame.render_widget(
         Paragraph::new(help).style(Style::default().bg(theme.surface)),
         area,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,9 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, BorderType, Borders, Cell, List, ListItem, Paragraph, Wrap},
 };
 
 use crate::app::{App, AppMode, Pane};
@@ -213,6 +213,40 @@ fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) 
     );
 }
 
+const TTL_BAR_WIDTH: usize = 8;
+const TTL_SECS: i64 = 300;
+
+pub(crate) fn ttl_cell_parts(remaining_secs: i64, theme: &Theme) -> (String, Color) {
+    if remaining_secs <= 0 {
+        return ("— expired".to_string(), theme.muted);
+    }
+    let mins = remaining_secs / 60;
+    let secs = remaining_secs % 60;
+    let ratio = remaining_secs as f64 / TTL_SECS as f64;
+    let filled = (ratio * TTL_BAR_WIDTH as f64).round() as usize;
+    let filled = filled.min(TTL_BAR_WIDTH);
+    let color = if ratio > 0.5 {
+        theme.pine
+    } else if ratio > 0.2 {
+        theme.gold
+    } else {
+        theme.love
+    };
+    let bar: String = "█".repeat(filled) + &"·".repeat(TTL_BAR_WIDTH - filled);
+    let text = format!("{:02}:{:02} {}", mins, secs, bar);
+    (text, color)
+}
+
+pub(crate) fn render_ttl_cell(remaining_secs: i64, theme: &Theme) -> Cell<'static> {
+    let (text, color) = ttl_cell_parts(remaining_secs, theme);
+    let style = if remaining_secs > 0 && remaining_secs < 60 {
+        Style::default().fg(color).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(color)
+    };
+    Cell::from(Line::from(Span::styled(text, style)))
+}
+
 fn format_size(bytes: u64) -> String {
     if bytes < 1024 {
         format!("{bytes}B")
@@ -235,5 +269,49 @@ mod tests {
     fn format_size_shows_kb_for_large() {
         assert_eq!(format_size(2048), "2.0K");
         assert_eq!(format_size(1536), "1.5K");
+    }
+
+    #[test]
+    fn ttl_cell_expired_has_em_dash() {
+        let theme = Theme::dark();
+        let (text, _) = ttl_cell_parts(0, &theme);
+        assert!(text.contains("— expired"));
+    }
+
+    #[test]
+    fn ttl_cell_has_mm_ss_format() {
+        let theme = Theme::dark();
+        let (text, _) = ttl_cell_parts(277, &theme);
+        assert!(text.starts_with("04:37"));
+    }
+
+    #[test]
+    fn ttl_cell_high_uses_pine() {
+        let theme = Theme::dark();
+        let (_, color) = ttl_cell_parts(270, &theme);
+        assert_eq!(color, theme.pine);
+    }
+
+    #[test]
+    fn ttl_cell_medium_uses_gold() {
+        let theme = Theme::dark();
+        let (_, color) = ttl_cell_parts(120, &theme);
+        assert_eq!(color, theme.gold);
+    }
+
+    #[test]
+    fn ttl_cell_low_uses_love() {
+        let theme = Theme::dark();
+        let (_, color) = ttl_cell_parts(30, &theme);
+        assert_eq!(color, theme.love);
+    }
+
+    #[test]
+    fn ttl_cell_bar_shrinks_as_time_elapses() {
+        let theme = Theme::dark();
+        let (full_text, _) = ttl_cell_parts(300, &theme);
+        let (empty_text, _) = ttl_cell_parts(1, &theme);
+        let filled = |s: &str| s.matches('█').count();
+        assert!(filled(&full_text) >= filled(&empty_text));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -413,7 +413,6 @@ fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) 
 }
 
 const TTL_BAR_WIDTH: usize = 8;
-const TTL_SECS: i64 = 300;
 
 pub(crate) fn ttl_cell_parts(remaining_secs: i64, theme: &Theme) -> (String, Color) {
     if remaining_secs <= 0 {
@@ -421,7 +420,7 @@ pub(crate) fn ttl_cell_parts(remaining_secs: i64, theme: &Theme) -> (String, Col
     }
     let mins = remaining_secs / 60;
     let secs = remaining_secs % 60;
-    let ratio = remaining_secs as f64 / TTL_SECS as f64;
+    let ratio = remaining_secs as f64 / sessions::TTL_SECS as f64;
     let filled = (ratio * TTL_BAR_WIDTH as f64).round() as usize;
     let filled = filled.min(TTL_BAR_WIDTH);
     let color = if ratio > 0.5 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,7 +11,7 @@ use ratatui::{
 
 use crate::app::{App, AppMode, Pane, SessionsPane};
 use crate::markdown;
-use crate::sessions::{self, State};
+use crate::sessions::{self, PermissionMode, State};
 use crate::theme::Theme;
 
 pub fn render(frame: &mut Frame, app: &App, theme: &Theme) {
@@ -49,7 +49,11 @@ fn render_memory_layout(frame: &mut Frame, app: &App, theme: &Theme, area: Rect)
 }
 
 fn render_sessions_layout(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
-    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(8)]).split(area);
+    let chunks = Layout::vertical([
+        Constraint::Min(1),
+        Constraint::Length(SESSION_DETAIL_HEIGHT),
+    ])
+    .split(area);
     render_sessions_table(frame, app, theme, chunks[0]);
     render_sessions_detail(frame, app, theme, chunks[1]);
 }
@@ -62,12 +66,9 @@ fn state_glyph(state: State, theme: &Theme) -> Span<'static> {
     }
 }
 
-fn mode_abbrev(mode: Option<&str>) -> &'static str {
+fn mode_abbrev(mode: Option<&PermissionMode>) -> &str {
     match mode {
-        Some("auto") => "auto",
-        Some("default") => "default",
-        Some("acceptEdits") => "accept",
-        Some(_) => "other",
+        Some(m) => m.abbrev(),
         None => "—",
     }
 }
@@ -80,16 +81,20 @@ fn relative_age(last: chrono::DateTime<chrono::Utc>, now: chrono::DateTime<chron
 fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     let focused = app.sessions_focus == SessionsPane::Table;
     let now = chrono::Utc::now();
-    let active = app
+
+    // One pass: compute per-entry state once; reuse for both the header
+    // counts and the row rendering. state_at is cheap but it's in the
+    // 100ms draw hot path × N rows × 3 callsites — collapse to one.
+    let states: Vec<State> = app
         .sessions
         .iter()
-        .filter(|e| sessions::state_at(e, now) == State::Active)
-        .count();
-    let idle = app
-        .sessions
-        .iter()
-        .filter(|e| sessions::state_at(e, now) == State::Idle)
-        .count();
+        .map(|e| sessions::state_at(e, now))
+        .collect();
+    let (active, idle) = states.iter().fold((0usize, 0usize), |(a, i), s| match s {
+        State::Active => (a + 1, i),
+        State::Idle => (a, i + 1),
+        State::Stale => (a, i),
+    });
     let title = format!("Sessions ({} active · {} idle)", active, idle);
     let block = pane_block(&title, focused, theme);
 
@@ -117,21 +122,21 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
     let rows: Vec<Row> = app
         .sessions
         .iter()
-        .map(|entry| {
-            let state = sessions::state_at(entry, now);
+        .zip(states.iter())
+        .map(|(entry, &state)| {
             let row_fg = match state {
                 State::Active => theme.text,
                 State::Idle => theme.muted,
                 State::Stale => theme.overlay,
             };
             let remaining = sessions::cache_ttl_remaining_secs(entry, now);
-            let project = sessions::middle_truncate(&entry.project_name, 22);
+            let project = sessions::middle_truncate(&entry.project_name, PROJECT_NAME_MAX_WIDTH);
 
             Row::new(vec![
                 Cell::from(Line::from(vec![Span::raw(" "), state_glyph(state, theme)])),
                 Cell::from(entry.short_id.clone()),
                 Cell::from(project),
-                Cell::from(mode_abbrev(entry.permission_mode.as_deref())),
+                Cell::from(mode_abbrev(entry.permission_mode.as_ref()).to_string()),
                 Cell::from(relative_age(entry.last_activity, now)),
                 render_ttl_cell(remaining, theme),
                 Cell::from(sessions::format_bytes(entry.file_size)),
@@ -206,7 +211,7 @@ fn render_sessions_detail(frame: &mut Frame, app: &App, theme: &Theme, area: Rec
         .unwrap_or_else(|| "—".to_string());
 
     let last_str = relative_age(entry.last_activity, now);
-    let mode_str = mode_abbrev(entry.permission_mode.as_deref());
+    let mode_str = mode_abbrev(entry.permission_mode.as_ref()).to_string();
 
     let lines = vec![
         Line::from(vec![
@@ -377,41 +382,55 @@ fn render_preview_pane(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 }
 
 fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) {
-    let help = match mode {
-        AppMode::Memory => Line::from(vec![
-            Span::styled(" ↑↓", Style::default().fg(theme.text)),
-            Span::styled(" navigate  ", Style::default().fg(theme.muted)),
-            Span::styled("←→", Style::default().fg(theme.text)),
-            Span::styled(" pane  ", Style::default().fg(theme.muted)),
-            Span::styled("e", Style::default().fg(theme.text)),
-            Span::styled(" edit  ", Style::default().fg(theme.muted)),
-            Span::styled("Tab", Style::default().fg(theme.text)),
-            Span::styled(" sessions  ", Style::default().fg(theme.muted)),
-            Span::styled("q", Style::default().fg(theme.text)),
-            Span::styled(" quit", Style::default().fg(theme.muted)),
-        ]),
-        AppMode::Sessions => Line::from(vec![
-            Span::styled(" ↑↓", Style::default().fg(theme.text)),
-            Span::styled(" navigate  ", Style::default().fg(theme.muted)),
-            Span::styled("←→", Style::default().fg(theme.text)),
-            Span::styled(" pane  ", Style::default().fg(theme.muted)),
-            Span::styled("s", Style::default().fg(theme.text)),
-            Span::styled(" sort  ", Style::default().fg(theme.muted)),
-            Span::styled("r", Style::default().fg(theme.text)),
-            Span::styled(" refresh  ", Style::default().fg(theme.muted)),
-            Span::styled("Tab", Style::default().fg(theme.text)),
-            Span::styled(" memory  ", Style::default().fg(theme.muted)),
-            Span::styled("q", Style::default().fg(theme.text)),
-            Span::styled(" quit", Style::default().fg(theme.muted)),
-        ]),
+    let entries: &[(&str, &str)] = match mode {
+        AppMode::Memory => &[
+            ("↑↓", "navigate"),
+            ("←→", "pane"),
+            ("e", "edit"),
+            ("Tab", "sessions"),
+            ("q", "quit"),
+        ],
+        AppMode::Sessions => &[
+            ("↑↓", "navigate"),
+            ("←→", "pane"),
+            ("s", "sort"),
+            ("r", "refresh"),
+            ("Tab", "memory"),
+            ("q", "quit"),
+        ],
     };
+
+    let mut spans = Vec::with_capacity(entries.len() * 2);
+    for (i, (key, label)) in entries.iter().enumerate() {
+        let prefix = if i == 0 { " " } else { "" };
+        spans.push(Span::styled(
+            format!("{prefix}{key}"),
+            Style::default().fg(theme.text),
+        ));
+        spans.push(Span::styled(
+            format!(" {label}  "),
+            Style::default().fg(theme.muted),
+        ));
+    }
+
     frame.render_widget(
-        Paragraph::new(help).style(Style::default().bg(theme.surface)),
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(theme.surface)),
         area,
     );
 }
 
 const TTL_BAR_WIDTH: usize = 8;
+
+/// Height of the Sessions-mode detail panel (includes 2 border rows).
+const SESSION_DETAIL_HEIGHT: u16 = 8;
+
+/// Max width the Project column renders before middle-truncating.
+const PROJECT_NAME_MAX_WIDTH: usize = 22;
+
+/// Cache-TTL color thresholds. Remaining-ratio above WARN → green, between
+/// CRIT and WARN → yellow, below CRIT → red + BOLD.
+const TTL_WARN_RATIO: f64 = 0.5;
+const TTL_CRIT_RATIO: f64 = 0.2;
 
 pub(crate) fn ttl_cell_parts(remaining_secs: i64, theme: &Theme) -> (String, Color) {
     if remaining_secs <= 0 {
@@ -422,9 +441,9 @@ pub(crate) fn ttl_cell_parts(remaining_secs: i64, theme: &Theme) -> (String, Col
     let ratio = remaining_secs as f64 / sessions::TTL_SECS as f64;
     let filled = (ratio * TTL_BAR_WIDTH as f64).round() as usize;
     let filled = filled.min(TTL_BAR_WIDTH);
-    let color = if ratio > 0.5 {
+    let color = if ratio > TTL_WARN_RATIO {
         theme.pine
-    } else if ratio > 0.2 {
+    } else if ratio > TTL_CRIT_RATIO {
         theme.gold
     } else {
         theme.love

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,13 +1,17 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Layout, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Cell, List, ListItem, Paragraph, Wrap},
+    widgets::{
+        Block, BorderType, Borders, Cell, HighlightSpacing, List, ListItem, Paragraph, Row, Table,
+        TableState, Wrap,
+    },
 };
 
-use crate::app::{App, AppMode, Pane};
+use crate::app::{App, AppMode, Pane, SessionsPane};
 use crate::markdown;
+use crate::sessions::{self, State};
 use crate::theme::Theme;
 
 pub fn render(frame: &mut Frame, app: &App, theme: &Theme) {
@@ -44,8 +48,210 @@ fn render_memory_layout(frame: &mut Frame, app: &App, theme: &Theme, area: Rect)
     render_preview_pane(frame, app, theme, chunks[2]);
 }
 
-fn render_sessions_layout(_frame: &mut Frame, _app: &App, _theme: &Theme, _area: Rect) {
-    // Implemented in Task 16
+fn render_sessions_layout(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(8)]).split(area);
+    render_sessions_table(frame, app, theme, chunks[0]);
+    render_sessions_detail(frame, app, theme, chunks[1]);
+}
+
+fn state_glyph(state: State, theme: &Theme) -> Span<'static> {
+    match state {
+        State::Active => Span::styled("●", Style::default().fg(theme.pine)),
+        State::Idle => Span::styled("◐", Style::default().fg(theme.muted)),
+        State::Stale => Span::styled("○", Style::default().fg(theme.overlay)),
+    }
+}
+
+fn mode_abbrev(mode: Option<&str>) -> &'static str {
+    match mode {
+        Some("auto") => "auto",
+        Some("default") => "default",
+        Some("acceptEdits") => "accept",
+        Some(_) => "other",
+        None => "—",
+    }
+}
+
+fn relative_age(
+    last: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> String {
+    let elapsed = (now - last).num_seconds().max(0);
+    sessions::format_duration(elapsed)
+}
+
+fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let focused = app.sessions_focus == SessionsPane::Table;
+    let now = chrono::Utc::now();
+    let active = app
+        .sessions
+        .iter()
+        .filter(|e| sessions::state_at(e, now) == State::Active)
+        .count();
+    let idle = app
+        .sessions
+        .iter()
+        .filter(|e| sessions::state_at(e, now) == State::Idle)
+        .count();
+    let title = format!("Sessions ({} active · {} idle)", active, idle);
+    let block = pane_block(&title, focused, theme);
+
+    if app.sessions.is_empty() {
+        let p = Paragraph::new("(no sessions found)")
+            .block(block)
+            .style(Style::default().fg(theme.muted).bg(theme.base))
+            .alignment(Alignment::Center);
+        frame.render_widget(p, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        "",
+        "ID",
+        "Project",
+        "Mode",
+        "Last",
+        "Cache TTL",
+        "Size",
+    ])
+    .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let rows: Vec<Row> = app
+        .sessions
+        .iter()
+        .map(|entry| {
+            let state = sessions::state_at(entry, now);
+            let row_fg = match state {
+                State::Active => theme.text,
+                State::Idle => theme.muted,
+                State::Stale => theme.overlay,
+            };
+            let remaining = sessions::cache_ttl_remaining_secs(entry, now);
+            let project = sessions::middle_truncate(&entry.project_name, 22);
+
+            Row::new(vec![
+                Cell::from(Line::from(vec![
+                    Span::raw(" "),
+                    state_glyph(state, theme),
+                ])),
+                Cell::from(entry.short_id.clone()),
+                Cell::from(project),
+                Cell::from(mode_abbrev(entry.permission_mode.as_deref())),
+                Cell::from(relative_age(entry.last_activity, now)),
+                render_ttl_cell(remaining, theme),
+                Cell::from(sessions::format_bytes(entry.file_size)),
+            ])
+            .style(Style::default().fg(row_fg))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(3),
+        Constraint::Length(8),
+        Constraint::Min(20),
+        Constraint::Length(9),
+        Constraint::Length(8),
+        Constraint::Length(14),
+        Constraint::Length(7),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(block)
+        .row_highlight_style(
+            Style::default()
+                .fg(theme.iris)
+                .bg(theme.overlay)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ")
+        .highlight_spacing(HighlightSpacing::Always)
+        .column_spacing(1);
+
+    let mut state = TableState::default();
+    state.select(Some(
+        app.session_index
+            .min(app.sessions.len().saturating_sub(1)),
+    ));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn render_sessions_detail(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let focused = app.sessions_focus == SessionsPane::Detail;
+
+    let Some(entry) = app.sessions.get(app.session_index) else {
+        let block = pane_block("Detail", focused, theme);
+        frame.render_widget(
+            Paragraph::new("")
+                .block(block)
+                .style(Style::default().bg(theme.base)),
+            area,
+        );
+        return;
+    };
+
+    let title = format!("{} · {}", entry.short_id, entry.project_name);
+    let block = pane_block(&title, focused, theme);
+
+    let now = chrono::Utc::now();
+    let remaining = sessions::cache_ttl_remaining_secs(entry, now);
+    let (ttl_text, ttl_color) = ttl_cell_parts(remaining, theme);
+
+    let started_line = match entry.started_at {
+        Some(ts) => {
+            let age = sessions::format_duration((now - ts).num_seconds().max(0));
+            format!("{} ({} ago)", ts.format("%Y-%m-%d %H:%M"), age)
+        }
+        None => "—".to_string(),
+    };
+
+    let cwd_display = entry
+        .cwd
+        .as_deref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "—".to_string());
+
+    let last_str = relative_age(entry.last_activity, now);
+    let mode_str = mode_abbrev(entry.permission_mode.as_deref());
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Session:    ", Style::default().fg(theme.muted)),
+            Span::raw(entry.session_id.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("Project:    ", Style::default().fg(theme.muted)),
+            Span::raw(entry.project_name.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("CWD:        ", Style::default().fg(theme.muted)),
+            Span::raw(cwd_display),
+        ]),
+        Line::from(vec![
+            Span::styled("Started:    ", Style::default().fg(theme.muted)),
+            Span::raw(started_line),
+            Span::styled("    Last: ", Style::default().fg(theme.muted)),
+            Span::raw(last_str),
+        ]),
+        Line::from(vec![
+            Span::styled("Mode:       ", Style::default().fg(theme.muted)),
+            Span::raw(mode_str),
+            Span::styled("    TTL: ", Style::default().fg(theme.muted)),
+            Span::styled(ttl_text, Style::default().fg(ttl_color)),
+            Span::raw(" ⏳"),
+        ]),
+        Line::from(vec![
+            Span::styled("Transcript: ", Style::default().fg(theme.muted)),
+            Span::raw(entry.transcript_path.to_string_lossy().to_string()),
+        ]),
+    ];
+
+    let p = Paragraph::new(lines)
+        .block(block)
+        .style(Style::default().fg(theme.text).bg(theme.base))
+        .scroll((app.session_scroll, 0));
+    frame.render_widget(p, area);
 }
 
 fn render_tab_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -232,7 +232,6 @@ fn render_sessions_detail(frame: &mut Frame, app: &App, theme: &Theme, area: Rec
             Span::raw(mode_str),
             Span::styled("    TTL: ", Style::default().fg(theme.muted)),
             Span::styled(ttl_text, Style::default().fg(ttl_color)),
-            Span::raw(" ⏳"),
         ]),
         Line::from(vec![
             Span::styled("Transcript: ", Style::default().fg(theme.muted)),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -339,7 +339,7 @@ fn render_files_pane(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
                     };
 
                     let prefix = if is_selected { "▸ " } else { "  " };
-                    let size = format_size(file.size);
+                    let size = sessions::format_bytes(file.size);
 
                     ListItem::new(Line::from(vec![
                         Span::styled(prefix, style),
@@ -444,29 +444,9 @@ pub(crate) fn render_ttl_cell(remaining_secs: i64, theme: &Theme) -> Cell<'stati
     Cell::from(Line::from(Span::styled(text, style)))
 }
 
-fn format_size(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{bytes}B")
-    } else {
-        format!("{:.1}K", bytes as f64 / 1024.0)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn format_size_shows_bytes_for_small() {
-        assert_eq!(format_size(100), "100B");
-        assert_eq!(format_size(0), "0B");
-    }
-
-    #[test]
-    fn format_size_shows_kb_for_large() {
-        assert_eq!(format_size(2048), "2.0K");
-        assert_eq!(format_size(1536), "1.5K");
-    }
 
     #[test]
     fn ttl_cell_expired_has_em_dash() {


### PR DESCRIPTION
## Summary
- New top-level "Sessions" mode, toggled from Memory via `Tab`
- Live table of Claude Code sessions under `~/.claude/projects/` with state glyph, short ID, project, permission mode, last activity, cache TTL countdown, file size
- Fixed 8-row detail panel below the table showing full metadata per session
- Hook-free, read-only, no network I/O — MVP1 of a 3-stage roadmap (observability → hooks → warming)

## Changes
### `src/sessions.rs` (new, ~700 lines)
- `SessionEntry`, `State`, `SessionsSort`, `SessionCache` types
- `parse_first_record` (first 10 lines) + `parse_tail` (8 KB tail seek) — hook-free JSONL extraction
- `scan_sessions` + mtime-diffed cache (no re-parse when file unchanged)
- `state_at`, `cache_ttl_remaining_secs`, `sort_entries` — pure helpers with tests
- `demo_sessions` fixture for `--demo` mode

### `src/app.rs`
- New `AppMode { Memory, Sessions }` and `SessionsPane { Table, Detail }` enums
- `handle_key` split into mode-dispatching top layer + `handle_key_memory` / `handle_key_sessions`
- `Tab`/`Shift-Tab` toggles mode; state preserved both directions
- `s` cycles sort, `r` sets `wants_refresh`, `g`/`G` jump, `j/k/h/l` per focus
- `refresh_sessions` + adaptive `refresh_interval` (1000 ms active / 2000 ms idle)
- `with_demo_sessions` + `skip_real_refresh` guard for `--demo`

### `src/ui.rs`
- Top-level tab bar (Memory | Sessions) + mode-aware help bar
- `render_sessions_layout`: Table with 7 columns + fixed detail Paragraph
- `render_ttl_cell` pure helper: `mm:ss ████▌·····` hybrid bar, color thresholds (pine > 50%, gold 20–50%, love < 20%), BOLD under 60 s
- Row styling by state (Active=text, Idle=muted, Stale=overlay)

### `src/main.rs`
- Pass `claude_dir` into `run_app`
- Periodic refresh tick (Sessions mode only) + `wants_refresh` consumption
- Demo mode wires `demo_sessions` via `with_demo_sessions`

### `Cargo.toml`
- `serde_json = "1"` (robust JSON parsing for user data)
- `chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }` (ISO 8601 timestamps + Duration arithmetic)

## Architecture notes
- **Hook-free by design** — MVP1 infers everything from `~/.claude/projects/*.jsonl` + mtime. MVP2 will add hook integration; MVP3 adds cache warming daemon.
- **Performance-aware scan** — Only first 10 lines read on discovery; only 8 KB tail read on mtime change; full file reads never happen.
- **State preservation** — Toggling Tab preserves both Memory indices/focus/scroll and Sessions index/focus/sort.
- **No breakage** — Memory mode rendering extracted into `render_memory_layout`, semantically identical. All 67 existing tests still pass.

## Tests
- **128 passing** (67 existing + 61 new)
- `src/sessions.rs`: 33 tests — formatters, state transitions, sort logic, JSONL parsers, cache diff
- `src/app.rs`: 31 tests (was 16) — mode toggle, state preservation, key handlers, sort cycle, clamp, refresh interval
- `src/ui.rs`: 8 tests (was 2) — TTL cell color thresholds, bar rendering, expired state

## Test plan
- [ ] `cargo test` → 128 pass
- [ ] `cargo clippy --all-targets -- -D warnings` → clean
- [ ] `cargo run -- --demo` → Memory mode loads; Tab → 5 demo sessions with live TTL countdowns; Tab back preserves state
- [ ] `cargo run` → real sessions from `~/.claude/projects/` appear within ~1 sec of pressing Tab
- [ ] `r` forces immediate refresh; `s` cycles sort; `g`/`G` jump; `q` quits from either mode
- [ ] Terminal width < 80 renders without panic (project column truncates first)

## Out of scope (deferred to MVP2/MVP3)
- Cache warming / API calls / launchd daemon
- Claude Code hook installation
- Filter (`/`), help overlay (`?`), prewarm (`p`)
- Turn count column (full-scan cost), model column (not in jsonl), token count

Detailed design: `docs/superpowers/specs/2026-04-19-sessions-view-design.md` (gitignored local)
Implementation plan: `docs/superpowers/plans/2026-04-19-sessions-view.md` (gitignored local)