### PR TITLE
feat: add Claude Code hook integration (MVP2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,8 +287,10 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "libc",
  "pulldown-cmark",
  "ratatui",
+ "serde",
  "serde_json",
  "tempfile",
 ]
@@ -755,6 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ dirs = "6"
 pulldown-cmark = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ crossterm = "0.28"
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 pulldown-cmark = { version = "0.13", default-features = false }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -93,19 +93,36 @@ Press `Tab` to switch between two modes:
 
 **Sessions mode** uses a Table + Detail layout:
 
-- **Table** — 6 columns: state glyph, short ID, project, last activity, cache TTL, size
-- **Detail** — Fixed 8-row panel showing full session metadata
+- **Table** — 7 columns: state glyph, short ID, project, mode, last activity, cache TTL, size
+- **Detail** — Fixed 9-row panel showing full session metadata
 
-Cache TTL is shown as a hybrid `mm:ss ████▌·····` bar with color thresholds (green > 50%, yellow 20–50%, red < 20%).
+Cache TTL is shown as a hybrid `mm:ss ████▌·····` bar with color thresholds (green > 50%, yellow 20–50%, red < 20%). Mode is sourced from Claude Code hooks when installed; shows `—` otherwise.
 
 ### State glyph
 
 Two-state, aligned with Anthropic's 5-minute prompt-cache TTL:
 
-- `●` warm — last write within 5 min (cache likely still live on the server)
-- `○` cold — last write older than 5 min (cache expired; resuming pays a miss)
+- `●` warm — last write within 5 min or hook registry reports alive
+- `○` cold — last write over 5 min, or hook registry reports terminated / dead PID
 
-duru cannot tell from disk alone whether a session's Claude Code process is still running. `/clear`, `/exit`, or a killed terminal leave the transcript file on disk and duru classifies it only by mtime.
+## Hooks
+
+Run `duru hooks install` to add Claude Code event hooks to `~/.claude/settings.json`. From then on, duru shows accurate permission mode, real `/exit` detection, and PID-based liveness instead of just mtime inference.
+
+Requires `jq` on PATH (macOS: `brew install jq`; Debian/Ubuntu: `apt-get install jq`).
+
+```bash
+duru hooks install                # interactive, asks about starring on first run
+duru hooks install --yes          # non-interactive, skips star prompt
+duru hooks install --dry-run      # preview only, no changes
+duru hooks status                 # show installation state
+duru hooks uninstall              # remove duru entries, preserve others
+duru hooks uninstall --force      # also delete ~/.claude/duru/
+```
+
+Hooks write per-session state into `~/.claude/duru/registry/<session_id>.json`. Terminated sessions are retained for 7 days, then auto-pruned. Installation preserves any non-duru hooks already in `settings.json`.
+
+duru is safe to run without installing hooks — it falls back to mtime-based inference.
 
 ## Theme
 

--- a/examples/bench_scan.rs
+++ b/examples/bench_scan.rs
@@ -37,13 +37,14 @@ fn main() {
     let n_warm = cache.entries().len();
 
     let t2 = Instant::now();
-    cache.refresh(&claude_dir);
-    let warm2_elapsed = t2.elapsed();
+    let reg = registry::Registry::load_all(&claude_dir);
+    let reg_elapsed = t2.elapsed();
 
     println!("Sessions discovered: {}", n_cold);
-    println!("Cold refresh (first scan):  {:?}", cold_elapsed);
-    println!("Warm refresh (mtime cache): {:?}", warm_elapsed);
-    println!("Warm refresh (again):       {:?}", warm2_elapsed);
+    println!("Registry entries:    {}", reg.len());
+    println!("Cold refresh:        {:?}", cold_elapsed);
+    println!("Warm refresh:        {:?}", warm_elapsed);
+    println!("Registry load:       {:?}", reg_elapsed);
     if n_cold != n_warm {
         eprintln!(
             "note: entry count changed between cold ({n_cold}) and warm ({n_warm}) refresh \

--- a/examples/bench_scan.rs
+++ b/examples/bench_scan.rs
@@ -3,6 +3,8 @@
 
 #![allow(dead_code)]
 
+#[path = "../src/registry.rs"]
+mod registry;
 #[path = "../src/scan.rs"]
 mod scan;
 #[path = "../src/sessions.rs"]

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -15,6 +15,8 @@ use ratatui::{Terminal, backend::TestBackend, style::Color};
 mod app;
 #[path = "../src/markdown.rs"]
 mod markdown;
+#[path = "../src/registry.rs"]
+mod registry;
 #[path = "../src/scan.rs"]
 mod scan;
 #[path = "../src/sessions.rs"]

--- a/src/_hook_scripts/session-end.sh
+++ b/src/_hook_scripts/session-end.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+[ -z "$SESSION_ID" ] && exit 0
+
+REGISTRY="$HOME/.claude/duru/registry/${SESSION_ID}.json"
+[ ! -f "$REGISTRY" ] && exit 0
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+REASON=$(echo "$INPUT" | jq -r '.reason // "other"')
+
+TMP=$(mktemp "${REGISTRY}.XXXXXX")
+jq --arg t "$NOW" --arg r "$REASON" \
+  '.terminated = true | .ended_at = $t | .end_reason = $r | .last_heartbeat = $t' \
+  "$REGISTRY" > "$TMP"
+mv "$TMP" "$REGISTRY"
+exit 0

--- a/src/_hook_scripts/session-start.sh
+++ b/src/_hook_scripts/session-start.sh
@@ -18,8 +18,10 @@ jq -n \
   --arg tr "$TRANSCRIPT" --arg src "$SOURCE" --arg mode "$MODE" \
   --argjson pid "$PID_VAL" \
   '{schema_version:1, session_id:$sid, pid:$pid, cwd:$cwd,
-    transcript_path:$tr, started_at:$hb, source:($src | select(. != "")),
-    last_heartbeat:$hb, permission_mode:($mode | select(. != "")),
+    transcript_path:$tr, started_at:$hb,
+    source:(if $src == "" then null else $src end),
+    last_heartbeat:$hb,
+    permission_mode:(if $mode == "" then null else $mode end),
     terminated:false}' \
   > "$TMP"
 mv "$TMP" "$REGISTRY"

--- a/src/_hook_scripts/session-start.sh
+++ b/src/_hook_scripts/session-start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+[ -z "$SESSION_ID" ] && exit 0
+
+REGISTRY="$HOME/.claude/duru/registry/${SESSION_ID}.json"
+mkdir -p "$(dirname "$REGISTRY")"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
+MODE=$(echo "$INPUT" | jq -r '.permission_mode // empty')
+PID_VAL="${PPID:-0}"
+
+TMP=$(mktemp "${REGISTRY}.XXXXXX")
+jq -n \
+  --arg sid "$SESSION_ID" --arg hb "$NOW" --arg cwd "$CWD" \
+  --arg tr "$TRANSCRIPT" --arg src "$SOURCE" --arg mode "$MODE" \
+  --argjson pid "$PID_VAL" \
+  '{schema_version:1, session_id:$sid, pid:$pid, cwd:$cwd,
+    transcript_path:$tr, started_at:$hb, source:($src | select(. != "")),
+    last_heartbeat:$hb, permission_mode:($mode | select(. != "")),
+    terminated:false}' \
+  > "$TMP"
+mv "$TMP" "$REGISTRY"
+exit 0

--- a/src/_hook_scripts/user-prompt-submit.sh
+++ b/src/_hook_scripts/user-prompt-submit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+[ -z "$SESSION_ID" ] && exit 0
+
+REGISTRY="$HOME/.claude/duru/registry/${SESSION_ID}.json"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+MODE=$(echo "$INPUT" | jq -r '.permission_mode // empty')
+
+TMP=$(mktemp "${REGISTRY}.XXXXXX")
+if [ -f "$REGISTRY" ]; then
+  jq --arg hb "$NOW" --arg mode "$MODE" \
+    '.last_heartbeat = $hb | if $mode != "" then .permission_mode = $mode else . end' \
+    "$REGISTRY" > "$TMP"
+else
+  mkdir -p "$(dirname "$REGISTRY")"
+  CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+  TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+  jq -n --arg sid "$SESSION_ID" --arg hb "$NOW" --arg mode "$MODE" \
+        --arg cwd "$CWD" --arg tr "$TRANSCRIPT" --argjson pid "${PPID:-0}" \
+    '{schema_version:1, session_id:$sid, pid:$pid, cwd:$cwd,
+      transcript_path:$tr, started_at:$hb, last_heartbeat:$hb,
+      permission_mode:($mode | select(. != "")), terminated:false}' \
+    > "$TMP"
+fi
+mv "$TMP" "$REGISTRY"
+exit 0

--- a/src/_hook_scripts/user-prompt-submit.sh
+++ b/src/_hook_scripts/user-prompt-submit.sh
@@ -20,7 +20,8 @@ else
         --arg cwd "$CWD" --arg tr "$TRANSCRIPT" --argjson pid "${PPID:-0}" \
     '{schema_version:1, session_id:$sid, pid:$pid, cwd:$cwd,
       transcript_path:$tr, started_at:$hb, last_heartbeat:$hb,
-      permission_mode:($mode | select(. != "")), terminated:false}' \
+      permission_mode:(if $mode == "" then null else $mode end),
+      terminated:false}' \
     > "$TMP"
 fi
 mv "$TMP" "$REGISTRY"

--- a/src/_hook_scripts/user-prompt-submit.sh
+++ b/src/_hook_scripts/user-prompt-submit.sh
@@ -4,6 +4,9 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 [ -z "$SESSION_ID" ] && exit 0
 
 REGISTRY="$HOME/.claude/duru/registry/${SESSION_ID}.json"
+# Ensure the registry dir exists before mktemp — SessionStart may have been
+# skipped (for instance on `claude --resume` the first time hooks are seen).
+mkdir -p "$(dirname "$REGISTRY")"
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 MODE=$(echo "$INPUT" | jq -r '.permission_mode // empty')
 
@@ -13,7 +16,6 @@ if [ -f "$REGISTRY" ]; then
     '.last_heartbeat = $hb | if $mode != "" then .permission_mode = $mode else . end' \
     "$REGISTRY" > "$TMP"
 else
-  mkdir -p "$(dirname "$REGISTRY")"
   CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
   TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
   jq -n --arg sid "$SESSION_ID" --arg hb "$NOW" --arg mode "$MODE" \

--- a/src/hook_scripts.rs
+++ b/src/hook_scripts.rs
@@ -1,0 +1,25 @@
+//! Embedded hook script contents. Written to disk by `duru hooks install`.
+//!
+//! Invariants:
+//!  - Always `exit 0` — never block Claude Code.
+//!  - Silent on stderr — avoid terminal corruption.
+//!  - Atomic write via mktemp + mv — no partial files visible.
+
+pub const SESSION_START_SH: &str = include_str!("_hook_scripts/session-start.sh");
+pub const USER_PROMPT_SUBMIT_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
+pub const PRE_TOOL_USE_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
+pub const POST_TOOL_USE_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
+pub const STOP_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
+pub const SESSION_END_SH: &str = include_str!("_hook_scripts/session-end.sh");
+
+/// Returns (filename, contents) for every hook this binary ships.
+pub fn all() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("session-start.sh", SESSION_START_SH),
+        ("user-prompt-submit.sh", USER_PROMPT_SUBMIT_SH),
+        ("pre-tool-use.sh", PRE_TOOL_USE_SH),
+        ("post-tool-use.sh", POST_TOOL_USE_SH),
+        ("stop.sh", STOP_SH),
+        ("session-end.sh", SESSION_END_SH),
+    ]
+}

--- a/src/hook_scripts.rs
+++ b/src/hook_scripts.rs
@@ -6,10 +6,17 @@
 //!  - Atomic write via mktemp + mv — no partial files visible.
 
 pub const SESSION_START_SH: &str = include_str!("_hook_scripts/session-start.sh");
+
+/// Heartbeat script shared by UserPromptSubmit, PreToolUse, PostToolUse, and
+/// Stop. All four events just touch `last_heartbeat` (and optionally refresh
+/// `permission_mode`). Intentional aliasing — if you add a distinct
+/// per-event script, create a new `_hook_scripts/<name>.sh` file and swap the
+/// constant below.
 pub const USER_PROMPT_SUBMIT_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
-pub const PRE_TOOL_USE_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
-pub const POST_TOOL_USE_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
-pub const STOP_SH: &str = include_str!("_hook_scripts/user-prompt-submit.sh");
+pub const PRE_TOOL_USE_SH: &str = USER_PROMPT_SUBMIT_SH;
+pub const POST_TOOL_USE_SH: &str = USER_PROMPT_SUBMIT_SH;
+pub const STOP_SH: &str = USER_PROMPT_SUBMIT_SH;
+
 pub const SESSION_END_SH: &str = include_str!("_hook_scripts/session-end.sh");
 
 /// Returns (filename, contents) for every hook this binary ships.

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -504,6 +504,27 @@ mod tests {
     }
 
     #[test]
+    fn install_respects_custom_home() {
+        // Prove that passing a custom `home` writes under that root and does
+        // NOT touch the real home directory. Sensitive because the hooks
+        // subcommand dispatches through `run_hooks_command(&hooks_home, ...)`
+        // which in turn derives hooks_home from `cli.path`.
+        let real_home = fake_home();
+        let custom_home = fake_home();
+        install(custom_home.path(), &opts_install_silent()).unwrap();
+        assert!(hooks_dir(custom_home.path()).is_dir());
+        assert!(settings_path(custom_home.path()).exists());
+        assert!(
+            !hooks_dir(real_home.path()).exists(),
+            "install must not touch real home"
+        );
+        assert!(
+            !settings_path(real_home.path()).exists(),
+            "install must not touch real home settings"
+        );
+    }
+
+    #[test]
     fn install_is_idempotent() {
         let home = fake_home();
         install(home.path(), &opts_install_silent()).unwrap();

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -144,11 +144,7 @@ fn merge_settings(home: &Path) -> std::io::Result<()> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(input.as_bytes())?;
+    child.stdin.as_mut().unwrap().write_all(input.as_bytes())?;
     let result = child.wait_with_output()?;
 
     if !result.status.success() {
@@ -233,6 +229,7 @@ fn try_star() {
 pub struct StatusReport {
     pub installed: bool,
     pub events_present: Vec<String>,
+    #[allow(dead_code)]
     pub events_missing: Vec<String>,
     pub registry_alive: usize,
     pub registry_terminated: usize,

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -170,6 +170,103 @@ fn maybe_star_prompt(_home: &Path, _opts: &InstallOpts) -> std::io::Result<()> {
     Ok(())
 }
 
+pub struct StatusReport {
+    pub installed: bool,
+    pub events_present: Vec<String>,
+    pub events_missing: Vec<String>,
+    pub registry_alive: usize,
+    pub registry_terminated: usize,
+}
+
+pub fn status(home: &Path) -> std::io::Result<StatusReport> {
+    let settings = settings_path(home);
+    let mut events_present = Vec::new();
+    let mut events_missing: Vec<String> = Vec::new();
+
+    if settings.exists() {
+        let raw = fs::read_to_string(&settings)?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| std::io::Error::other(format!("settings.json invalid: {e}")))?;
+        let hooks = &parsed["hooks"];
+        for event in EVENTS {
+            let has_duru = hooks[event]
+                .as_array()
+                .map(|arr| {
+                    arr.iter().any(|e| {
+                        e["_duru"] == true
+                            || e["hooks"]
+                                .as_array()
+                                .map(|hs| {
+                                    hs.iter().any(|h| {
+                                        h["command"]
+                                            .as_str()
+                                            .map(|c| c.contains(".claude/duru/hooks/"))
+                                            .unwrap_or(false)
+                                    })
+                                })
+                                .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false);
+            if has_duru {
+                events_present.push((*event).to_string());
+            } else {
+                events_missing.push((*event).to_string());
+            }
+        }
+    } else {
+        events_missing = EVENTS.iter().map(|s| (*s).to_string()).collect();
+    }
+
+    let mut alive = 0usize;
+    let mut terminated = 0usize;
+    if let Ok(read_dir) = fs::read_dir(registry_dir(home)) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if let Ok(bytes) = fs::read(&path)
+                && let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&bytes)
+            {
+                if parsed["terminated"] == true {
+                    terminated += 1;
+                } else {
+                    alive += 1;
+                }
+            }
+        }
+    }
+
+    Ok(StatusReport {
+        installed: events_missing.is_empty(),
+        events_present,
+        events_missing,
+        registry_alive: alive,
+        registry_terminated: terminated,
+    })
+}
+
+pub fn print_status(report: &StatusReport) {
+    println!(
+        "Hooks installed: {}",
+        if report.installed { "yes" } else { "no" }
+    );
+    for event in EVENTS {
+        let marker = if report.events_present.contains(&(*event).to_string()) {
+            "✓"
+        } else {
+            "✗"
+        };
+        println!("  {event:18} {marker}");
+    }
+    println!();
+    println!(
+        "Registry entries: {} alive, {} terminated",
+        report.registry_alive, report.registry_terminated
+    );
+}
+
 pub fn uninstall(home: &Path, opts: &UninstallOpts) -> std::io::Result<()> {
     if !check_jq_available() {
         eprintln!("error: `jq` is required but not found on PATH.");
@@ -392,6 +489,49 @@ mod tests {
             .iter()
             .any(|e| e["hooks"][0]["command"].as_str() == Some("bash /other/hook.sh"));
         assert!(has_other);
+    }
+
+    #[test]
+    fn status_reports_installed_when_all_six_present() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        let report = status(home.path()).unwrap();
+        assert!(report.installed);
+        for event in EVENTS {
+            assert!(
+                report.events_present.contains(&(*event).to_string()),
+                "{event} not reported present"
+            );
+        }
+    }
+
+    #[test]
+    fn status_reports_not_installed_on_empty_settings() {
+        let home = fake_home();
+        let report = status(home.path()).unwrap();
+        assert!(!report.installed);
+        assert!(report.events_present.is_empty());
+    }
+
+    #[test]
+    fn status_reports_registry_count() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        fs::write(
+            registry_dir(home.path()).join("abc.json"),
+            r#"{
+                "schema_version": 1,
+                "session_id": "abc",
+                "cwd": "/tmp",
+                "transcript_path": "/tmp/abc.jsonl",
+                "started_at": "2026-04-20T00:00:00Z",
+                "last_heartbeat": "2026-04-20T00:00:00Z",
+                "terminated": false
+            }"#,
+        )
+        .unwrap();
+        let report = status(home.path()).unwrap();
+        assert_eq!(report.registry_alive, 1);
     }
 
     #[test]

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::hook_scripts;
+
+pub struct InstallOpts {
+    pub dry_run: bool,
+    pub yes: bool,
+    pub star: bool,
+    pub force_star_prompt: bool,
+}
+
+pub struct UninstallOpts {
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+pub const EVENTS: &[&str] = &[
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "Stop",
+    "SessionEnd",
+];
+
+fn script_filename(event: &str) -> &'static str {
+    match event {
+        "SessionStart" => "session-start.sh",
+        "UserPromptSubmit" => "user-prompt-submit.sh",
+        "PreToolUse" => "pre-tool-use.sh",
+        "PostToolUse" => "post-tool-use.sh",
+        "Stop" => "stop.sh",
+        "SessionEnd" => "session-end.sh",
+        _ => unreachable!("unknown event: {event}"),
+    }
+}
+
+pub fn duru_dir(home: &Path) -> PathBuf {
+    home.join(".claude/duru")
+}
+
+pub fn hooks_dir(home: &Path) -> PathBuf {
+    duru_dir(home).join("hooks")
+}
+
+pub fn registry_dir(home: &Path) -> PathBuf {
+    duru_dir(home).join("registry")
+}
+
+pub fn settings_path(home: &Path) -> PathBuf {
+    home.join(".claude/settings.json")
+}
+
+pub fn check_jq_available() -> bool {
+    Command::new("jq")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+pub fn install(home: &Path, opts: &InstallOpts) -> std::io::Result<()> {
+    if !check_jq_available() {
+        eprintln!("error: `jq` is required but not found on PATH.");
+        eprintln!("  macOS: brew install jq");
+        eprintln!("  Debian/Ubuntu: apt-get install jq");
+        return Err(std::io::Error::other("jq missing"));
+    }
+
+    if opts.dry_run {
+        println!("[dry-run] would create {}", hooks_dir(home).display());
+        println!("[dry-run] would create {}", registry_dir(home).display());
+        for (name, _) in hook_scripts::all() {
+            println!("[dry-run] would write {}/{name}", hooks_dir(home).display());
+        }
+        println!(
+            "[dry-run] would merge 6 hook entries into {}",
+            settings_path(home).display()
+        );
+        return Ok(());
+    }
+
+    fs::create_dir_all(hooks_dir(home))?;
+    fs::create_dir_all(registry_dir(home))?;
+    for (name, content) in hook_scripts::all() {
+        let path = hooks_dir(home).join(name);
+        fs::write(&path, content)?;
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms)?;
+    }
+
+    merge_settings(home)?;
+
+    println!("✓ Hooks installed.");
+    println!("  6 events registered in {}", settings_path(home).display());
+    println!("  Registry at {}", registry_dir(home).display());
+
+    maybe_star_prompt(home, opts)?;
+    Ok(())
+}
+
+fn merge_settings(home: &Path) -> std::io::Result<()> {
+    let settings = settings_path(home);
+    let hooks_dir_p = hooks_dir(home);
+
+    let backup_name = format!(
+        "settings.json.duru.bak.{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    );
+    if settings.exists() {
+        fs::copy(&settings, home.join(".claude").join(&backup_name))?;
+    }
+
+    let mut jq_expr = String::from(". as $orig | $orig | .hooks = (( .hooks // {} )");
+    for event in EVENTS {
+        let script_path = hooks_dir_p
+            .join(script_filename(event))
+            .to_string_lossy()
+            .to_string();
+        let command_str = format!("bash {script_path}");
+        jq_expr.push_str(&format!(
+            " | .[\"{event}\"] = ((.[\"{event}\"] // []) + \
+             [{{\"_duru\": true, \"hooks\": [{{\"type\": \"command\", \
+             \"command\": \"{command_str}\"}}]}}])"
+        ));
+    }
+    jq_expr.push(')');
+
+    let input = if settings.exists() {
+        fs::read_to_string(&settings)?
+    } else {
+        "{}".to_string()
+    };
+
+    let mut child = Command::new("jq")
+        .arg(&jq_expr)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())?;
+    let result = child.wait_with_output()?;
+
+    if !result.status.success() {
+        return Err(std::io::Error::other("jq merge failed"));
+    }
+    if serde_json::from_slice::<serde_json::Value>(&result.stdout).is_err() {
+        return Err(std::io::Error::other("merged settings invalid JSON"));
+    }
+
+    let tmp = settings.with_extension("json.duru.tmp");
+    fs::write(&tmp, &result.stdout)?;
+    fs::rename(&tmp, &settings)?;
+
+    Ok(())
+}
+
+fn maybe_star_prompt(_home: &Path, _opts: &InstallOpts) -> std::io::Result<()> {
+    // Implemented in T16.
+    Ok(())
+}

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -169,3 +169,126 @@ fn maybe_star_prompt(_home: &Path, _opts: &InstallOpts) -> std::io::Result<()> {
     // Implemented in T16.
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_home() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        tmp
+    }
+
+    fn opts_install_silent() -> InstallOpts {
+        InstallOpts {
+            dry_run: false,
+            yes: true,
+            star: false,
+            force_star_prompt: false,
+        }
+    }
+
+    #[test]
+    fn install_creates_hooks_and_registry_dirs() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        assert!(hooks_dir(home.path()).is_dir());
+        assert!(registry_dir(home.path()).is_dir());
+    }
+
+    #[test]
+    fn install_writes_six_hook_scripts() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        for (name, _) in hook_scripts::all() {
+            let p = hooks_dir(home.path()).join(name);
+            assert!(p.is_file(), "{} missing", p.display());
+        }
+    }
+
+    #[test]
+    fn install_creates_valid_json_settings_from_scratch() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        for event in EVENTS {
+            assert!(parsed["hooks"][event].is_array(), "{event} not array");
+        }
+    }
+
+    #[test]
+    fn install_preserves_existing_non_duru_hooks_and_env() {
+        let home = fake_home();
+        let existing = r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash /some/other/hook.sh"}]}
+                ]
+            },
+            "env": {"FOO": "bar"}
+        }"#;
+        fs::write(settings_path(home.path()), existing).unwrap();
+        install(home.path(), &opts_install_silent()).unwrap();
+
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let pre = parsed["hooks"]["PreToolUse"].as_array().unwrap();
+        let has_other = pre
+            .iter()
+            .any(|e| e["hooks"][0]["command"].as_str() == Some("bash /some/other/hook.sh"));
+        assert!(has_other, "existing non-duru hook must be preserved");
+        assert_eq!(parsed["env"]["FOO"].as_str(), Some("bar"));
+    }
+
+    #[test]
+    fn install_marks_entries_with_duru_flag() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        for event in EVENTS {
+            let entries = parsed["hooks"][event].as_array().unwrap();
+            assert!(
+                entries.iter().any(|e| e["_duru"] == true),
+                "{event} has no duru-marked entry"
+            );
+        }
+    }
+
+    #[test]
+    fn install_creates_backup_when_settings_exists() {
+        let home = fake_home();
+        fs::write(settings_path(home.path()), r#"{"hooks":{}}"#).unwrap();
+        install(home.path(), &opts_install_silent()).unwrap();
+        let claude_dir = home.path().join(".claude");
+        let backups: Vec<_> = fs::read_dir(&claude_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("settings.json.duru.bak.")
+            })
+            .collect();
+        assert_eq!(backups.len(), 1);
+    }
+
+    #[test]
+    fn install_dry_run_does_not_modify() {
+        let home = fake_home();
+        install(
+            home.path(),
+            &InstallOpts {
+                dry_run: true,
+                yes: true,
+                star: false,
+                force_star_prompt: false,
+            },
+        )
+        .unwrap();
+        assert!(!hooks_dir(home.path()).exists());
+        assert!(!settings_path(home.path()).exists());
+    }
+}

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -118,6 +118,15 @@ fn merge_settings(home: &Path) -> std::io::Result<()> {
         fs::copy(&settings, home.join(".claude").join(&backup_name))?;
     }
 
+    // Build a jq expression that, for each event:
+    //  (1) strips any pre-existing duru entries (identified by _duru marker
+    //      OR command path containing ".claude/duru/hooks/"), then
+    //  (2) appends the fresh duru entry.
+    // This makes `install` idempotent — running it twice yields the same
+    // settings.json as running it once. The command string is passed via
+    // `jq --arg` (not interpolated) so paths containing quotes or
+    // backslashes don't break the filter syntax.
+    let mut jq_args: Vec<String> = Vec::new();
     let mut jq_expr = String::from(". as $orig | $orig | .hooks = (( .hooks // {} )");
     for event in EVENTS {
         let script_path = hooks_dir_p
@@ -125,10 +134,16 @@ fn merge_settings(home: &Path) -> std::io::Result<()> {
             .to_string_lossy()
             .to_string();
         let command_str = format!("bash {script_path}");
+        let arg_name = format!("cmd_{event}");
+        jq_args.push("--arg".to_string());
+        jq_args.push(arg_name.clone());
+        jq_args.push(command_str);
         jq_expr.push_str(&format!(
-            " | .[\"{event}\"] = ((.[\"{event}\"] // []) + \
-             [{{\"_duru\": true, \"hooks\": [{{\"type\": \"command\", \
-             \"command\": \"{command_str}\"}}]}}])"
+            " | .[\"{event}\"] = \
+               ([(.[\"{event}\"] // [])[] | \
+                 select(._duru != true \
+                   and ((.hooks // []) | all(((.command // \"\")) | contains(\".claude/duru/hooks/\") | not)))] \
+                + [{{\"_duru\": true, \"hooks\": [{{\"type\": \"command\", \"command\": ${arg_name}}}]}}])"
         ));
     }
     jq_expr.push(')');
@@ -139,11 +154,12 @@ fn merge_settings(home: &Path) -> std::io::Result<()> {
         "{}".to_string()
     };
 
-    let mut child = Command::new("jq")
-        .arg(&jq_expr)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()?;
+    let mut cmd = Command::new("jq");
+    for arg in &jq_args {
+        cmd.arg(arg);
+    }
+    cmd.arg(&jq_expr);
+    let mut child = cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
     child.stdin.as_mut().unwrap().write_all(input.as_bytes())?;
     let result = child.wait_with_output()?;
 
@@ -286,6 +302,11 @@ pub fn status(home: &Path) -> std::io::Result<StatusReport> {
             if let Ok(bytes) = fs::read(&path)
                 && let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&bytes)
             {
+                // Align with Registry::load_all: only count entries whose
+                // schema we can actually read.
+                if parsed["schema_version"] != crate::registry::CURRENT_SCHEMA_VERSION {
+                    continue;
+                }
                 if parsed["terminated"] == true {
                     terminated += 1;
                 } else {
@@ -478,6 +499,23 @@ mod tests {
             assert!(
                 entries.iter().any(|e| e["_duru"] == true),
                 "{event} has no duru-marked entry"
+            );
+        }
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        install(home.path(), &opts_install_silent()).unwrap();
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        for event in EVENTS {
+            let arr = parsed["hooks"][event].as_array().unwrap();
+            let duru_count = arr.iter().filter(|e| e["_duru"] == true).count();
+            assert_eq!(
+                duru_count, 1,
+                "{event} has {duru_count} duru entries after two installs"
             );
         }
     }

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -170,6 +170,77 @@ fn maybe_star_prompt(_home: &Path, _opts: &InstallOpts) -> std::io::Result<()> {
     Ok(())
 }
 
+pub fn uninstall(home: &Path, opts: &UninstallOpts) -> std::io::Result<()> {
+    if !check_jq_available() {
+        eprintln!("error: `jq` is required but not found on PATH.");
+        return Err(std::io::Error::other("jq missing"));
+    }
+
+    if opts.dry_run {
+        println!(
+            "[dry-run] would remove duru hook entries from {}",
+            settings_path(home).display()
+        );
+        if opts.force {
+            println!("[dry-run] would remove {}", duru_dir(home).display());
+        }
+        return Ok(());
+    }
+
+    let settings = settings_path(home);
+    if !settings.exists() {
+        return Ok(());
+    }
+
+    let backup_name = format!(
+        "settings.json.duru.bak.{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    );
+    fs::copy(&settings, home.join(".claude").join(&backup_name))?;
+
+    let input = fs::read_to_string(&settings)?;
+    let filter_expr = r#"
+        if .hooks == null then . else
+          .hooks |= with_entries(
+            .value |= map(
+              select(
+                (._duru != true) and
+                ((.hooks // []) | all((.command // "") | contains(".claude/duru/hooks/") | not))
+              )
+            )
+          )
+        end
+    "#;
+
+    let mut child = Command::new("jq")
+        .arg(filter_expr)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+    child.stdin.as_mut().unwrap().write_all(input.as_bytes())?;
+    let result = child.wait_with_output()?;
+    if !result.status.success() {
+        return Err(std::io::Error::other("jq filter failed"));
+    }
+    if serde_json::from_slice::<serde_json::Value>(&result.stdout).is_err() {
+        return Err(std::io::Error::other("filtered settings invalid JSON"));
+    }
+
+    let tmp = settings.with_extension("json.duru.tmp");
+    fs::write(&tmp, &result.stdout)?;
+    fs::rename(&tmp, &settings)?;
+
+    if opts.force {
+        let _ = fs::remove_dir_all(duru_dir(home));
+    }
+
+    println!("✓ Hooks uninstalled.");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -273,6 +344,83 @@ mod tests {
             })
             .collect();
         assert_eq!(backups.len(), 1);
+    }
+
+    fn opts_uninstall_silent() -> UninstallOpts {
+        UninstallOpts {
+            dry_run: false,
+            force: false,
+        }
+    }
+
+    #[test]
+    fn uninstall_removes_duru_entries() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        uninstall(home.path(), &opts_uninstall_silent()).unwrap();
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        for event in EVENTS {
+            let arr = parsed["hooks"][event].as_array();
+            if let Some(arr) = arr {
+                assert!(
+                    !arr.iter().any(|e| e["_duru"] == true),
+                    "{event} still has duru entry"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn uninstall_preserves_non_duru_hooks() {
+        let home = fake_home();
+        let existing = r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash /other/hook.sh"}]}
+                ]
+            }
+        }"#;
+        fs::write(settings_path(home.path()), existing).unwrap();
+        install(home.path(), &opts_install_silent()).unwrap();
+        uninstall(home.path(), &opts_uninstall_silent()).unwrap();
+
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let pre = parsed["hooks"]["PreToolUse"].as_array().unwrap();
+        let has_other = pre
+            .iter()
+            .any(|e| e["hooks"][0]["command"].as_str() == Some("bash /other/hook.sh"));
+        assert!(has_other);
+    }
+
+    #[test]
+    fn uninstall_identifies_by_command_path_even_without_marker() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+
+        // Strip the _duru markers to simulate a user who edited settings.json.
+        let raw = fs::read_to_string(settings_path(home.path())).unwrap();
+        let stripped = raw
+            .replace("\"_duru\": true,", "")
+            .replace("\"_duru\":true,", "");
+        fs::write(settings_path(home.path()), stripped).unwrap();
+
+        uninstall(home.path(), &opts_uninstall_silent()).unwrap();
+
+        let s = fs::read_to_string(settings_path(home.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        for event in EVENTS {
+            if let Some(arr) = parsed["hooks"][event].as_array() {
+                for e in arr.iter() {
+                    let cmd = e["hooks"][0]["command"].as_str().unwrap_or("");
+                    assert!(
+                        !cmd.contains(".claude/duru/hooks/"),
+                        "duru path still present after uninstall: {cmd}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -165,9 +165,69 @@ fn merge_settings(home: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn maybe_star_prompt(_home: &Path, _opts: &InstallOpts) -> std::io::Result<()> {
-    // Implemented in T16.
+fn maybe_star_prompt(home: &Path, opts: &InstallOpts) -> std::io::Result<()> {
+    let marker = duru_dir(home).join(".star-prompted");
+
+    // --yes skips the prompt (CI / scripted installs), unless --star pre-approved.
+    if opts.yes && !opts.star {
+        return Ok(());
+    }
+
+    // Already asked, unless --force-star-prompt.
+    if marker.exists() && !opts.force_star_prompt {
+        return Ok(());
+    }
+
+    let consent = if opts.star { true } else { prompt_star() };
+
+    fs::create_dir_all(duru_dir(home))?;
+    fs::write(&marker, "")?;
+
+    if consent {
+        try_star();
+    }
     Ok(())
+}
+
+fn prompt_star() -> bool {
+    println!();
+    println!("If duru helped you, a GitHub star makes it discoverable to");
+    println!("other Claude Code users. Would you like me to star it now?  [y/N]");
+    use std::io::{self, BufRead};
+    let stdin = io::stdin();
+    let mut line = String::new();
+    if stdin.lock().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim(), "y" | "Y" | "yes" | "Yes")
+}
+
+fn try_star() {
+    if Command::new("gh").arg("--version").output().is_err() {
+        println!("gh CLI not found. Star manually at:");
+        println!("  https://github.com/uppinote20/duru");
+        return;
+    }
+    let auth_ok = Command::new("gh")
+        .args(["auth", "status"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !auth_ok {
+        println!("gh is installed but not authenticated. Run `gh auth login`,");
+        println!("then: gh repo star uppinote20/duru");
+        return;
+    }
+    let star_ok = Command::new("gh")
+        .args(["repo", "star", "uppinote20/duru"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if star_ok {
+        println!("★ Thanks!");
+    } else {
+        println!("  (gh repo star failed — star manually at https://github.com/uppinote20/duru)");
+    }
 }
 
 pub struct StatusReport {
@@ -489,6 +549,51 @@ mod tests {
             .iter()
             .any(|e| e["hooks"][0]["command"].as_str() == Some("bash /other/hook.sh"));
         assert!(has_other);
+    }
+
+    #[test]
+    fn star_prompt_skipped_when_yes_flag() {
+        let home = fake_home();
+        install(home.path(), &opts_install_silent()).unwrap();
+        // With yes=true and star=false, the marker is NOT created.
+        assert!(!duru_dir(home.path()).join(".star-prompted").exists());
+    }
+
+    #[test]
+    fn explicit_star_flag_sets_marker() {
+        let home = fake_home();
+        install(
+            home.path(),
+            &InstallOpts {
+                dry_run: false,
+                yes: false,
+                star: true,
+                force_star_prompt: false,
+            },
+        )
+        .unwrap();
+        assert!(duru_dir(home.path()).join(".star-prompted").exists());
+    }
+
+    #[test]
+    fn prior_star_marker_prevents_re_prompt() {
+        let home = fake_home();
+        // Pre-create the marker and install without --yes and without --star.
+        fs::create_dir_all(duru_dir(home.path())).unwrap();
+        fs::write(duru_dir(home.path()).join(".star-prompted"), "").unwrap();
+
+        install(
+            home.path(),
+            &InstallOpts {
+                dry_run: false,
+                yes: false,
+                star: false,
+                force_star_prompt: false,
+            },
+        )
+        .unwrap();
+        // Marker still there; no prompt interaction because prior marker.
+        assert!(duru_dir(home.path()).join(".star-prompted").exists());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 mod app;
 mod hook_scripts;
+mod hooks_install;
 mod markdown;
 mod registry;
 mod scan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,8 +132,19 @@ fn main() -> io::Result<()> {
 
     let home = dirs::home_dir().ok_or_else(|| io::Error::other("no home dir"))?;
 
+    // `--path <dir>` treats <dir> as the `.claude` root, so the home directory
+    // we pass into the hooks command is the parent of <dir>. When `--path` is
+    // omitted, the real home directory is used.
+    let hooks_home = match &cli.path {
+        Some(claude_root) => claude_root
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| home.clone()),
+        None => home.clone(),
+    };
+
     if let Some(TopCommand::Hooks { action }) = cli.command {
-        return run_hooks_command(&home, action);
+        return run_hooks_command(&hooks_home, action);
     }
 
     let claude_dir = cli.path.clone().unwrap_or_else(|| home.join(".claude"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::collapsible_match, clippy::collapsible_if)]
 
 mod app;
+mod hook_scripts;
 mod markdown;
 mod registry;
 mod scan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,11 @@ use scan::{demo_projects, scan_claude_dir};
 use theme::Theme;
 
 #[derive(Parser)]
-#[command(name = "duru", version, about = "Claude Code memory and sessions dashboard")]
+#[command(
+    name = "duru",
+    version,
+    about = "Claude Code memory and sessions dashboard"
+)]
 struct Cli {
     /// Force color theme (dark or light)
     #[arg(long)]
@@ -112,10 +116,9 @@ fn run_hooks_command(home: &std::path::Path, action: HooksAction) -> io::Result<
                 force_star_prompt,
             },
         ),
-        HooksAction::Uninstall { dry_run, force } => hooks_install::uninstall(
-            home,
-            &hooks_install::UninstallOpts { dry_run, force },
-        ),
+        HooksAction::Uninstall { dry_run, force } => {
+            hooks_install::uninstall(home, &hooks_install::UninstallOpts { dry_run, force })
+        }
         HooksAction::Status => {
             let report = hooks_install::status(home)?;
             hooks_install::print_status(&report);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::io;
 use std::path::PathBuf;
 use std::process::Command;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -28,7 +28,7 @@ use scan::{demo_projects, scan_claude_dir};
 use theme::Theme;
 
 #[derive(Parser)]
-#[command(name = "duru", version, about = "Claude Code memory viewer")]
+#[command(name = "duru", version, about = "Claude Code memory and sessions dashboard")]
 struct Cli {
     /// Force color theme (dark or light)
     #[arg(long)]
@@ -41,6 +41,47 @@ struct Cli {
     /// Use demo data (for screenshots and testing)
     #[arg(long)]
     demo: bool,
+
+    #[command(subcommand)]
+    command: Option<TopCommand>,
+}
+
+#[derive(Subcommand)]
+enum TopCommand {
+    /// Install, uninstall, or check duru Claude Code hooks
+    Hooks {
+        #[command(subcommand)]
+        action: HooksAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum HooksAction {
+    /// Install duru hooks into ~/.claude/settings.json
+    Install {
+        /// Don't modify anything; print what would happen
+        #[arg(long)]
+        dry_run: bool,
+        /// Non-interactive; skip star prompt
+        #[arg(long)]
+        yes: bool,
+        /// Star the repo without asking
+        #[arg(long)]
+        star: bool,
+        /// Re-ask the star prompt even if previously asked
+        #[arg(long)]
+        force_star_prompt: bool,
+    },
+    /// Remove duru hooks from ~/.claude/settings.json
+    Uninstall {
+        #[arg(long)]
+        dry_run: bool,
+        /// Also delete ~/.claude/duru/ (hooks, registry, markers)
+        #[arg(long)]
+        force: bool,
+    },
+    /// Show current hook installation status
+    Status,
 }
 
 fn resolve_editor() -> String {
@@ -55,14 +96,44 @@ fn resolve_editor_from(visual: Option<&str>, editor: Option<&str>) -> String {
     visual.or(editor).unwrap_or("vi").to_string()
 }
 
+fn run_hooks_command(home: &std::path::Path, action: HooksAction) -> io::Result<()> {
+    match action {
+        HooksAction::Install {
+            dry_run,
+            yes,
+            star,
+            force_star_prompt,
+        } => hooks_install::install(
+            home,
+            &hooks_install::InstallOpts {
+                dry_run,
+                yes,
+                star,
+                force_star_prompt,
+            },
+        ),
+        HooksAction::Uninstall { dry_run, force } => hooks_install::uninstall(
+            home,
+            &hooks_install::UninstallOpts { dry_run, force },
+        ),
+        HooksAction::Status => {
+            let report = hooks_install::status(home)?;
+            hooks_install::print_status(&report);
+            Ok(())
+        }
+    }
+}
+
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
-    let claude_dir = cli.path.clone().unwrap_or_else(|| {
-        dirs::home_dir()
-            .expect("cannot resolve home directory")
-            .join(".claude")
-    });
+    let home = dirs::home_dir().ok_or_else(|| io::Error::other("no home dir"))?;
+
+    if let Some(TopCommand::Hooks { action }) = cli.command {
+        return run_hooks_command(&home, action);
+    }
+
+    let claude_dir = cli.path.clone().unwrap_or_else(|| home.join(".claude"));
 
     let projects = if cli.demo {
         demo_projects()

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 mod app;
 mod markdown;
+mod registry;
 mod scan;
 mod sessions;
 mod theme;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -39,3 +39,40 @@ pub enum RegistrySource {
     Alive,
     Terminated,
 }
+
+/// Returns true if a process with `pid` currently exists.
+/// Uses `kill(pid, 0)` — zero signal means "check only, don't deliver".
+/// `EPERM` (process exists but not ours to signal) also counts as alive.
+pub fn is_pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let pid_t = pid as libc::pid_t;
+    let rc = unsafe { libc::kill(pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    let err = std::io::Error::last_os_error().raw_os_error();
+    err == Some(libc::EPERM)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_pid_alive_returns_true_for_current_process() {
+        let own_pid = std::process::id();
+        assert!(is_pid_alive(own_pid));
+    }
+
+    #[test]
+    fn is_pid_alive_returns_false_for_impossible_pid() {
+        assert!(!is_pid_alive(4_000_000));
+    }
+
+    #[test]
+    fn is_pid_alive_for_zero_returns_false() {
+        assert!(!is_pid_alive(0));
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -75,6 +75,34 @@ impl Registry {
             .and_then(|sid| self.by_session_id.get(sid))
     }
 
+    /// Deletes terminated entries whose `ended_at` is older than
+    /// `TERMINATED_TTL_SECS`. Alive entries are always kept. Delete failures
+    /// (permission, race) are silently skipped; caller retries next refresh.
+    pub fn cleanup_expired(claude_dir: &Path, now: DateTime<Utc>) {
+        let dir = claude_dir.join(REGISTRY_DIR_REL);
+        let Ok(read_dir) = fs::read_dir(&dir) else {
+            return;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(bytes) = fs::read(&path) else { continue };
+            let Ok(parsed) = serde_json::from_slice::<RegistryEntry>(&bytes) else {
+                continue;
+            };
+            if !parsed.terminated {
+                continue;
+            }
+            let Some(ended) = parsed.ended_at else { continue };
+            let age = (now - ended).num_seconds();
+            if age > TERMINATED_TTL_SECS {
+                let _ = fs::remove_file(&path);
+            }
+        }
+    }
+
     /// Loads every well-formed `*.json` file under `<claude_dir>/duru/registry/`.
     /// Corrupt files, files with unknown schema_version, or files that fail
     /// deserialization are silently skipped — duru falls back to MVP1
@@ -250,6 +278,71 @@ mod tests {
         );
         let reg = Registry::load_all(tmp.path());
         assert!(reg.get_by_session_id("future").is_none());
+    }
+
+    fn write_entry_with_ended(
+        dir: &std::path::Path,
+        session_id: &str,
+        terminated: bool,
+        ended_at: Option<DateTime<Utc>>,
+    ) -> std::path::PathBuf {
+        let ended_str = match ended_at {
+            Some(t) => format!(r#","ended_at":"{}""#, t.to_rfc3339()),
+            None => String::new(),
+        };
+        let content = format!(
+            r#"{{
+                "schema_version": 1,
+                "session_id": "{sid}",
+                "cwd": "/tmp",
+                "transcript_path": "/tmp/{sid}.jsonl",
+                "started_at": "2026-04-20T00:00:00Z",
+                "last_heartbeat": "2026-04-20T00:00:00Z",
+                "terminated": {term}{ended}
+            }}"#,
+            sid = session_id,
+            term = terminated,
+            ended = ended_str
+        );
+        write_entry(dir, session_id, &content)
+    }
+
+    #[test]
+    fn cleanup_expired_removes_old_terminated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        let long_ago = Utc::now() - chrono::Duration::days(10);
+        let path = write_entry_with_ended(&dir, "old", true, Some(long_ago));
+
+        Registry::cleanup_expired(tmp.path(), Utc::now());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn cleanup_preserves_recent_terminated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        let recent = Utc::now() - chrono::Duration::days(3);
+        let path = write_entry_with_ended(&dir, "recent", true, Some(recent));
+
+        Registry::cleanup_expired(tmp.path(), Utc::now());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn cleanup_preserves_alive_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        let path = write_entry_with_ended(&dir, "alive", false, None);
+
+        Registry::cleanup_expired(tmp.path(), Utc::now());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn cleanup_missing_dir_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        Registry::cleanup_expired(tmp.path(), Utc::now());
     }
 
     fn sample_entry(last_hb_secs_ago: i64, terminated: bool, pid: Option<u32>) -> RegistryEntry {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -53,18 +53,22 @@ impl Registry {
         Self::default()
     }
 
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.by_session_id.len()
     }
 
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.by_session_id.is_empty()
     }
 
+    #[allow(dead_code)]
     pub fn entries(&self) -> impl Iterator<Item = &RegistryEntry> {
         self.by_session_id.values()
     }
 
+    #[allow(dead_code)]
     pub fn get_by_session_id(&self, sid: &str) -> Option<&RegistryEntry> {
         self.by_session_id.get(sid)
     }
@@ -95,7 +99,9 @@ impl Registry {
             if !parsed.terminated {
                 continue;
             }
-            let Some(ended) = parsed.ended_at else { continue };
+            let Some(ended) = parsed.ended_at else {
+                continue;
+            };
             let age = (now - ended).num_seconds();
             if age > TERMINATED_TTL_SECS {
                 let _ = fs::remove_file(&path);
@@ -359,7 +365,11 @@ mod tests {
             permission_mode: Some("auto".to_string()),
             terminated,
             ended_at: if terminated { Some(now) } else { None },
-            end_reason: if terminated { Some("other".to_string()) } else { None },
+            end_reason: if terminated {
+                Some("other".to_string())
+            } else {
+                None
+            },
         }
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Path suffix under the claude_dir for registry files.
+pub const REGISTRY_DIR_REL: &str = "duru/registry";
+
+/// Terminated entries older than this are pruned by `cleanup_expired`.
+pub const TERMINATED_TTL_SECS: i64 = 7 * 86_400;
+
+/// Currently supported schema for per-session registry JSON.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RegistryEntry {
+    pub schema_version: u32,
+    pub session_id: String,
+    #[serde(default)]
+    pub pid: Option<u32>,
+    pub cwd: PathBuf,
+    pub transcript_path: PathBuf,
+    pub started_at: DateTime<Utc>,
+    #[serde(default)]
+    pub source: Option<String>,
+    pub last_heartbeat: DateTime<Utc>,
+    #[serde(default)]
+    pub permission_mode: Option<String>,
+    #[serde(default)]
+    pub terminated: bool,
+    #[serde(default)]
+    pub ended_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub end_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistrySource {
+    Alive,
+    Terminated,
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -105,6 +105,23 @@ impl Registry {
     }
 }
 
+/// Derives the user-visible state for an entry.
+/// - Terminated flag from the registry wins unconditionally.
+/// - Dead pid → Terminated.
+/// - Missing pid → Alive (cannot prove death).
+/// - Otherwise Alive.
+pub fn classify(entry: &RegistryEntry) -> RegistrySource {
+    if entry.terminated {
+        return RegistrySource::Terminated;
+    }
+    if let Some(pid) = entry.pid
+        && !is_pid_alive(pid)
+    {
+        return RegistrySource::Terminated;
+    }
+    RegistrySource::Alive
+}
+
 /// Returns true if a process with `pid` currently exists.
 /// Uses `kill(pid, 0)` — zero signal means "check only, don't deliver".
 /// `EPERM` (process exists but not ours to signal) also counts as alive.
@@ -233,6 +250,48 @@ mod tests {
         );
         let reg = Registry::load_all(tmp.path());
         assert!(reg.get_by_session_id("future").is_none());
+    }
+
+    fn sample_entry(last_hb_secs_ago: i64, terminated: bool, pid: Option<u32>) -> RegistryEntry {
+        let now = Utc::now();
+        RegistryEntry {
+            schema_version: 1,
+            session_id: "test".to_string(),
+            pid,
+            cwd: PathBuf::from("/tmp"),
+            transcript_path: PathBuf::from("/tmp/test.jsonl"),
+            started_at: now - chrono::Duration::hours(1),
+            source: Some("startup".to_string()),
+            last_heartbeat: now - chrono::Duration::seconds(last_hb_secs_ago),
+            permission_mode: Some("auto".to_string()),
+            terminated,
+            ended_at: if terminated { Some(now) } else { None },
+            end_reason: if terminated { Some("other".to_string()) } else { None },
+        }
+    }
+
+    #[test]
+    fn classify_alive_when_not_terminated_and_pid_alive() {
+        let entry = sample_entry(30, false, Some(std::process::id()));
+        assert_eq!(classify(&entry), RegistrySource::Alive);
+    }
+
+    #[test]
+    fn classify_terminated_flag_true() {
+        let entry = sample_entry(30, true, Some(std::process::id()));
+        assert_eq!(classify(&entry), RegistrySource::Terminated);
+    }
+
+    #[test]
+    fn classify_dead_pid_is_terminated() {
+        let entry = sample_entry(30, false, Some(4_000_000));
+        assert_eq!(classify(&entry), RegistrySource::Terminated);
+    }
+
+    #[test]
+    fn classify_no_pid_and_not_terminated_is_alive() {
+        let entry = sample_entry(30, false, None);
+        assert_eq!(classify(&entry), RegistrySource::Alive);
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -40,6 +42,69 @@ pub enum RegistrySource {
     Terminated,
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct Registry {
+    by_session_id: HashMap<String, RegistryEntry>,
+    by_transcript_path: HashMap<PathBuf, String>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_session_id.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_session_id.is_empty()
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = &RegistryEntry> {
+        self.by_session_id.values()
+    }
+
+    pub fn get_by_session_id(&self, sid: &str) -> Option<&RegistryEntry> {
+        self.by_session_id.get(sid)
+    }
+
+    pub fn get_by_transcript_path(&self, path: &Path) -> Option<&RegistryEntry> {
+        self.by_transcript_path
+            .get(path)
+            .and_then(|sid| self.by_session_id.get(sid))
+    }
+
+    /// Loads every well-formed `*.json` file under `<claude_dir>/duru/registry/`.
+    /// Corrupt files, files with unknown schema_version, or files that fail
+    /// deserialization are silently skipped — duru falls back to MVP1
+    /// behavior for the corresponding session.
+    pub fn load_all(claude_dir: &Path) -> Self {
+        let dir = claude_dir.join(REGISTRY_DIR_REL);
+        let mut out = Self::new();
+        let Ok(read_dir) = fs::read_dir(&dir) else {
+            return out;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(bytes) = fs::read(&path) else { continue };
+            let Ok(parsed) = serde_json::from_slice::<RegistryEntry>(&bytes) else {
+                continue;
+            };
+            if parsed.schema_version != CURRENT_SCHEMA_VERSION {
+                continue;
+            }
+            out.by_transcript_path
+                .insert(parsed.transcript_path.clone(), parsed.session_id.clone());
+            out.by_session_id.insert(parsed.session_id.clone(), parsed);
+        }
+        out
+    }
+}
+
 /// Returns true if a process with `pid` currently exists.
 /// Uses `kill(pid, 0)` — zero signal means "check only, don't deliver".
 /// `EPERM` (process exists but not ours to signal) also counts as alive.
@@ -74,5 +139,123 @@ mod tests {
     #[test]
     fn is_pid_alive_for_zero_returns_false() {
         assert!(!is_pid_alive(0));
+    }
+
+    use std::io::Write;
+
+    fn write_entry(dir: &std::path::Path, session_id: &str, contents: &str) -> std::path::PathBuf {
+        fs::create_dir_all(dir).unwrap();
+        let path = dir.join(format!("{session_id}.json"));
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn load_all_empty_dir_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = Registry::load_all(tmp.path());
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn load_all_missing_dir_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = Registry::load_all(&tmp.path().join("does-not-exist"));
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn load_all_parses_valid_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        write_entry(
+            &dir,
+            "abc123",
+            r#"{
+                "schema_version": 1,
+                "session_id": "abc123",
+                "pid": 12345,
+                "cwd": "/tmp/proj",
+                "transcript_path": "/tmp/proj/abc123.jsonl",
+                "started_at": "2026-04-20T00:00:00Z",
+                "last_heartbeat": "2026-04-20T00:05:00Z",
+                "permission_mode": "auto",
+                "terminated": false
+            }"#,
+        );
+        let reg = Registry::load_all(tmp.path());
+        let entry = reg.get_by_session_id("abc123").unwrap();
+        assert_eq!(entry.session_id, "abc123");
+        assert_eq!(entry.pid, Some(12345));
+        assert_eq!(entry.permission_mode.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn load_all_skips_corrupt_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        write_entry(&dir, "bad", "{ not json");
+        write_entry(
+            &dir,
+            "good",
+            r#"{
+                "schema_version": 1,
+                "session_id": "good",
+                "cwd": "/tmp",
+                "transcript_path": "/tmp/good.jsonl",
+                "started_at": "2026-04-20T00:00:00Z",
+                "last_heartbeat": "2026-04-20T00:00:00Z",
+                "terminated": false
+            }"#,
+        );
+        let reg = Registry::load_all(tmp.path());
+        assert!(reg.get_by_session_id("good").is_some());
+        assert!(reg.get_by_session_id("bad").is_none());
+    }
+
+    #[test]
+    fn load_all_skips_wrong_schema_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        write_entry(
+            &dir,
+            "future",
+            r#"{
+                "schema_version": 99,
+                "session_id": "future",
+                "cwd": "/tmp",
+                "transcript_path": "/tmp/f.jsonl",
+                "started_at": "2026-04-20T00:00:00Z",
+                "last_heartbeat": "2026-04-20T00:00:00Z",
+                "terminated": false
+            }"#,
+        );
+        let reg = Registry::load_all(tmp.path());
+        assert!(reg.get_by_session_id("future").is_none());
+    }
+
+    #[test]
+    fn load_all_finds_by_transcript_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(REGISTRY_DIR_REL);
+        write_entry(
+            &dir,
+            "xid",
+            r#"{
+                "schema_version": 1,
+                "session_id": "xid",
+                "cwd": "/tmp/p",
+                "transcript_path": "/tmp/p/xid.jsonl",
+                "started_at": "2026-04-20T00:00:00Z",
+                "last_heartbeat": "2026-04-20T00:00:00Z",
+                "terminated": false
+            }"#,
+        );
+        let reg = Registry::load_all(tmp.path());
+        let entry = reg
+            .get_by_transcript_path(std::path::Path::new("/tmp/p/xid.jsonl"))
+            .unwrap();
+        assert_eq!(entry.session_id, "xid");
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -260,9 +260,7 @@ pub(crate) fn dedup_same_pid(
                 (Some(a), Some(b)) => (a - b).num_seconds().abs() < 60,
                 _ => true,
             };
-            if close_enough
-                && let Some((e, _)) = entries.get_mut(p)
-            {
+            if close_enough && let Some((e, _)) = entries.get_mut(p) {
                 e.registry_source = Some(RegistrySource::Terminated);
             }
         }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -224,6 +224,51 @@ pub struct SessionCache {
     by_path: HashMap<PathBuf, (SessionEntry, SystemTime)>,
 }
 
+/// For each pid that appears on multiple Alive entries, keep the entry with
+/// the most recent `last_activity` as Alive; mark the others Terminated.
+/// Uses `(pid, started_at)` identity — entries with started_at more than
+/// 60s apart are treated as distinct processes (pid-reuse guard).
+pub(crate) fn dedup_same_pid(
+    entries: &mut std::collections::HashMap<PathBuf, (SessionEntry, SystemTime)>,
+    pid_lookup: &std::collections::HashMap<PathBuf, u32>,
+) {
+    use std::collections::HashMap;
+
+    let mut groups: HashMap<u32, Vec<PathBuf>> = HashMap::new();
+    for (path, (entry, _)) in entries.iter() {
+        if entry.registry_source != Some(RegistrySource::Alive) {
+            continue;
+        }
+        if let Some(&pid) = pid_lookup.get(path) {
+            groups.entry(pid).or_default().push(path.clone());
+        }
+    }
+
+    for (_, paths) in groups.iter().filter(|(_, p)| p.len() > 1) {
+        let latest = paths
+            .iter()
+            .max_by_key(|p| entries[*p].0.last_activity)
+            .cloned()
+            .unwrap();
+        let latest_started = entries[&latest].0.started_at;
+        for p in paths {
+            if *p == latest {
+                continue;
+            }
+            let this_started = entries[p].0.started_at;
+            let close_enough = match (latest_started, this_started) {
+                (Some(a), Some(b)) => (a - b).num_seconds().abs() < 60,
+                _ => true,
+            };
+            if close_enough
+                && let Some((e, _)) = entries.get_mut(p)
+            {
+                e.registry_source = Some(RegistrySource::Terminated);
+            }
+        }
+    }
+}
+
 impl SessionCache {
     pub fn new() -> Self {
         Self::default()
@@ -258,11 +303,16 @@ impl SessionCache {
 
         // 2. Load registry and merge hook-sourced signals where paths match.
         let reg = Registry::load_all(claude_dir);
+        let mut pid_lookup: std::collections::HashMap<PathBuf, u32> =
+            std::collections::HashMap::new();
         for (path, (entry, _)) in self.by_path.iter_mut() {
             if let Some(reg_entry) = reg.get_by_transcript_path(path) {
                 entry.permission_mode = reg_entry.permission_mode.clone();
                 entry.registry_source = Some(registry::classify(reg_entry));
                 entry.is_alive = reg_entry.pid.map(registry::is_pid_alive);
+                if let Some(pid) = reg_entry.pid {
+                    pid_lookup.insert(path.clone(), pid);
+                }
             } else {
                 entry.permission_mode = None;
                 entry.registry_source = None;
@@ -270,7 +320,10 @@ impl SessionCache {
             }
         }
 
-        // 3. Prune terminated entries older than TERMINATED_TTL_SECS.
+        // 3. /clear detection: same pid on multiple alive entries → older → Terminated.
+        dedup_same_pid(&mut self.by_path, &pid_lookup);
+
+        // 4. Prune terminated entries older than TERMINATED_TTL_SECS.
         Registry::cleanup_expired(claude_dir, chrono::Utc::now());
     }
 }
@@ -562,6 +615,103 @@ mod tests {
         let now = Utc::now();
         let entry = make_entry("x", now - chrono::Duration::seconds(30));
         assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn dedup_same_pid_marks_older_as_terminated() {
+        use std::collections::HashMap;
+        use std::time::SystemTime;
+
+        let now = Utc::now();
+        let pid = 54321;
+        let mut entry_old = make_entry("old", now - chrono::Duration::minutes(5));
+        entry_old.started_at = Some(now - chrono::Duration::minutes(10));
+        entry_old.registry_source = Some(RegistrySource::Alive);
+        let mut entry_new = make_entry("new", now - chrono::Duration::seconds(30));
+        // started_at 30s apart from entry_old — within the 60s same-process window
+        entry_new.started_at = Some(now - chrono::Duration::seconds(10 * 60 - 30));
+        entry_new.registry_source = Some(RegistrySource::Alive);
+
+        let mut entries: HashMap<PathBuf, (SessionEntry, SystemTime)> = HashMap::new();
+        entries.insert(
+            PathBuf::from("/tmp/old.jsonl"),
+            (entry_old, SystemTime::UNIX_EPOCH),
+        );
+        entries.insert(
+            PathBuf::from("/tmp/new.jsonl"),
+            (entry_new, SystemTime::UNIX_EPOCH),
+        );
+
+        let mut pid_lookup: HashMap<PathBuf, u32> = HashMap::new();
+        pid_lookup.insert(PathBuf::from("/tmp/old.jsonl"), pid);
+        pid_lookup.insert(PathBuf::from("/tmp/new.jsonl"), pid);
+
+        dedup_same_pid(&mut entries, &pid_lookup);
+
+        assert_eq!(
+            entries[&PathBuf::from("/tmp/old.jsonl")].0.registry_source,
+            Some(RegistrySource::Terminated)
+        );
+        assert_eq!(
+            entries[&PathBuf::from("/tmp/new.jsonl")].0.registry_source,
+            Some(RegistrySource::Alive)
+        );
+    }
+
+    #[test]
+    fn dedup_ignores_different_pids() {
+        use std::collections::HashMap;
+        use std::time::SystemTime;
+
+        let now = Utc::now();
+        let mut a = make_entry("a", now);
+        a.registry_source = Some(RegistrySource::Alive);
+        let mut b = make_entry("b", now);
+        b.registry_source = Some(RegistrySource::Alive);
+
+        let mut entries: HashMap<PathBuf, (SessionEntry, SystemTime)> = HashMap::new();
+        entries.insert(PathBuf::from("/tmp/a.jsonl"), (a, SystemTime::UNIX_EPOCH));
+        entries.insert(PathBuf::from("/tmp/b.jsonl"), (b, SystemTime::UNIX_EPOCH));
+
+        let mut pid_lookup: HashMap<PathBuf, u32> = HashMap::new();
+        pid_lookup.insert(PathBuf::from("/tmp/a.jsonl"), 111);
+        pid_lookup.insert(PathBuf::from("/tmp/b.jsonl"), 222);
+
+        dedup_same_pid(&mut entries, &pid_lookup);
+
+        for (_, (e, _)) in entries.iter() {
+            assert_eq!(e.registry_source, Some(RegistrySource::Alive));
+        }
+    }
+
+    #[test]
+    fn dedup_ignores_same_pid_different_started_at() {
+        use std::collections::HashMap;
+        use std::time::SystemTime;
+
+        let now = Utc::now();
+        let pid = 77777;
+        let mut a = make_entry("a", now - chrono::Duration::seconds(30));
+        a.started_at = Some(now - chrono::Duration::hours(5));
+        a.registry_source = Some(RegistrySource::Alive);
+        let mut b = make_entry("b", now - chrono::Duration::seconds(10));
+        b.started_at = Some(now - chrono::Duration::seconds(20));
+        b.registry_source = Some(RegistrySource::Alive);
+
+        let mut entries: HashMap<PathBuf, (SessionEntry, SystemTime)> = HashMap::new();
+        entries.insert(PathBuf::from("/tmp/a.jsonl"), (a, SystemTime::UNIX_EPOCH));
+        entries.insert(PathBuf::from("/tmp/b.jsonl"), (b, SystemTime::UNIX_EPOCH));
+
+        let mut pid_lookup: HashMap<PathBuf, u32> = HashMap::new();
+        pid_lookup.insert(PathBuf::from("/tmp/a.jsonl"), pid);
+        pid_lookup.insert(PathBuf::from("/tmp/b.jsonl"), pid);
+
+        dedup_same_pid(&mut entries, &pid_lookup);
+
+        // started_at 5h apart → treat as different processes → both alive.
+        for (_, (e, _)) in entries.iter() {
+            assert_eq!(e.registry_source, Some(RegistrySource::Alive));
+        }
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -101,7 +101,18 @@ const SHORT_ID_LEN: usize = 8;
 /// when `~/.claude/projects` has thousands of historical transcripts.
 const LAZY_PARSE_CUTOFF_SECS: i64 = 86_400; // 24 h
 
+/// Classifies a session.
+///
+/// When a hook registry entry is available, its signals are authoritative:
+/// Terminated flag → Stale; dead pid → Stale. Otherwise falls back to the
+/// pure-mtime heuristic keyed on the 5-minute prompt-cache TTL.
 pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
+    if let Some(RegistrySource::Terminated) = entry.registry_source {
+        return State::Stale;
+    }
+    if entry.is_alive == Some(false) {
+        return State::Stale;
+    }
     let elapsed = (now - entry.last_activity).num_seconds();
     if elapsed < TTL_SECS {
         State::Active
@@ -499,6 +510,37 @@ mod tests {
     fn state_at_active_when_recent() {
         let now = Utc::now();
         let entry = make_entry("a", now - chrono::Duration::seconds(30));
+        assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn state_at_registry_terminated_overrides_mtime_recent() {
+        let now = Utc::now();
+        let mut entry = make_entry("x", now - chrono::Duration::seconds(30));
+        entry.registry_source = Some(RegistrySource::Terminated);
+        assert_eq!(state_at(&entry, now), State::Stale);
+    }
+
+    #[test]
+    fn state_at_registry_alive_uses_mtime() {
+        let now = Utc::now();
+        let mut entry = make_entry("x", now - chrono::Duration::seconds(30));
+        entry.registry_source = Some(RegistrySource::Alive);
+        assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn state_at_dead_pid_overrides_mtime_recent() {
+        let now = Utc::now();
+        let mut entry = make_entry("x", now - chrono::Duration::seconds(30));
+        entry.is_alive = Some(false);
+        assert_eq!(state_at(&entry, now), State::Stale);
+    }
+
+    #[test]
+    fn state_at_no_registry_falls_back_to_mtime() {
+        let now = Utc::now();
+        let entry = make_entry("x", now - chrono::Duration::seconds(30));
         assert_eq!(state_at(&entry, now), State::Active);
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -8,6 +8,8 @@ use chrono::{DateTime, Utc};
 
 use crate::scan::decode_project_name;
 
+use crate::registry::RegistrySource;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionEntry {
     pub session_id: String,
@@ -18,6 +20,9 @@ pub struct SessionEntry {
     pub started_at: Option<DateTime<Utc>>,
     pub last_activity: DateTime<Utc>,
     pub file_size: u64,
+    pub permission_mode: Option<String>,
+    pub registry_source: Option<RegistrySource>,
+    pub is_alive: Option<bool>,
 }
 
 /// Two-state model aligned with Anthropic's 5-minute prompt cache TTL:
@@ -322,6 +327,9 @@ fn parse_session_at(path: &Path, now: DateTime<Utc>) -> Option<SessionEntry> {
         started_at: first.started_at,
         last_activity,
         file_size: meta.len(),
+        permission_mode: None,
+        registry_source: None,
+        is_alive: None,
     })
 }
 
@@ -348,6 +356,9 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
             started_at: Some(last_activity - chrono::Duration::minutes(15)),
             last_activity,
             file_size: size,
+            permission_mode: None,
+            registry_source: None,
+            is_alive: None,
         }
     };
     vec![
@@ -478,6 +489,9 @@ mod tests {
             started_at: Some(last_activity),
             last_activity,
             file_size: 1000,
+            permission_mode: None,
+            registry_source: None,
+            is_alive: None,
         }
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -256,6 +256,11 @@ pub(crate) fn dedup_same_pid(
                 continue;
             }
             let this_started = entries[p].0.started_at;
+            // If either entry lacks started_at we fall through to the dedup
+            // (treat as same process). Very old transcripts from before hooks
+            // existed may have no started_at, so this can over-eagerly mark
+            // such entries Terminated — acceptable since they would be Stale
+            // by mtime anyway.
             let close_enough = match (latest_started, this_started) {
                 (Some(a), Some(b)) => (a - b).num_seconds().abs() < 60,
                 _ => true,

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -234,6 +234,9 @@ impl SessionCache {
     }
 
     pub fn refresh(&mut self, claude_dir: &Path) {
+        use crate::registry::{self, Registry};
+
+        // 1. Collect transcript files and (re-)parse by mtime.
         let found = walk_session_files(claude_dir);
         let found_paths: std::collections::HashSet<PathBuf> =
             found.iter().map(|(p, _)| p.clone()).collect();
@@ -252,6 +255,23 @@ impl SessionCache {
                 self.by_path.insert(path.clone(), (entry, mtime));
             }
         }
+
+        // 2. Load registry and merge hook-sourced signals where paths match.
+        let reg = Registry::load_all(claude_dir);
+        for (path, (entry, _)) in self.by_path.iter_mut() {
+            if let Some(reg_entry) = reg.get_by_transcript_path(path) {
+                entry.permission_mode = reg_entry.permission_mode.clone();
+                entry.registry_source = Some(registry::classify(reg_entry));
+                entry.is_alive = reg_entry.pid.map(registry::is_pid_alive);
+            } else {
+                entry.permission_mode = None;
+                entry.registry_source = None;
+                entry.is_alive = None;
+            }
+        }
+
+        // 3. Prune terminated entries older than TERMINATED_TTL_SECS.
+        Registry::cleanup_expired(claude_dir, chrono::Utc::now());
     }
 }
 
@@ -542,6 +562,53 @@ mod tests {
         let now = Utc::now();
         let entry = make_entry("x", now - chrono::Duration::seconds(30));
         assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn cache_refresh_merges_registry_into_entry() {
+        use crate::registry::REGISTRY_DIR_REL;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let proj_dir = tmp.path().join("projects").join("-Users-test-proj");
+        fs::create_dir_all(&proj_dir).unwrap();
+        let uuid = "zzzz1111-2222-3333-4444-555566667777";
+        let jsonl = proj_dir.join(format!("{uuid}.jsonl"));
+        fs::write(
+            &jsonl,
+            r#"{"type":"user","timestamp":"2026-04-20T00:00:00Z"}"#,
+        )
+        .unwrap();
+
+        let reg_dir = tmp.path().join(REGISTRY_DIR_REL);
+        fs::create_dir_all(&reg_dir).unwrap();
+        fs::write(
+            reg_dir.join(format!("{uuid}.json")),
+            format!(
+                r#"{{
+                    "schema_version": 1,
+                    "session_id": "{uuid}",
+                    "cwd": "/tmp/test-proj",
+                    "transcript_path": "{}",
+                    "started_at": "2026-04-20T00:00:00Z",
+                    "last_heartbeat": "2026-04-20T00:00:30Z",
+                    "permission_mode": "auto",
+                    "terminated": false
+                }}"#,
+                jsonl.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let mut cache = SessionCache::new();
+        cache.refresh(tmp.path());
+
+        let entries = cache.entries();
+        let entry = entries
+            .iter()
+            .find(|e| e.session_id == uuid)
+            .expect("session entry should exist");
+        assert_eq!(entry.permission_mode.as_deref(), Some("auto"));
+        assert_eq!(entry.registry_source, Some(RegistrySource::Alive));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -70,6 +70,17 @@ fn relative_age(last: chrono::DateTime<chrono::Utc>, now: chrono::DateTime<chron
     sessions::format_duration(elapsed)
 }
 
+fn mode_abbrev(mode: Option<&str>) -> &'static str {
+    match mode {
+        Some("auto") => "auto",
+        Some("default") => "default",
+        Some("acceptEdits") => "accept",
+        Some("plan") => "plan",
+        Some(_) => "other",
+        None => "—",
+    }
+}
+
 fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     let focused = app.sessions_focus == SessionsPane::Table;
     let now = chrono::Utc::now();
@@ -93,9 +104,11 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
         return;
     }
 
-    let header = Row::new(vec!["", "ID", "Project", "Last", "Cache TTL", "Size"])
-        .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
-        .bottom_margin(1);
+    let header = Row::new(vec![
+        "", "ID", "Project", "Mode", "Last", "Cache TTL", "Size",
+    ])
+    .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
 
     let rows: Vec<Row> = app
         .sessions
@@ -113,6 +126,7 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
                 Cell::from(Line::from(vec![Span::raw(" "), state_glyph(state, theme)])),
                 Cell::from(entry.short_id.clone()),
                 Cell::from(project),
+                Cell::from(mode_abbrev(entry.permission_mode.as_deref()).to_string()),
                 Cell::from(relative_age(entry.last_activity, now)),
                 render_ttl_cell(remaining, theme),
                 Cell::from(sessions::format_bytes(entry.file_size)),
@@ -125,6 +139,7 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
         Constraint::Length(3),
         Constraint::Length(8),
         Constraint::Min(20),
+        Constraint::Length(9),
         Constraint::Length(8),
         Constraint::Length(14),
         Constraint::Length(7),
@@ -199,6 +214,10 @@ fn render_sessions_detail(frame: &mut Frame, app: &App, theme: &Theme, area: Rec
         Line::from(vec![
             Span::styled("CWD:        ", Style::default().fg(theme.muted)),
             Span::raw(cwd_display),
+        ]),
+        Line::from(vec![
+            Span::styled("Mode:       ", Style::default().fg(theme.muted)),
+            Span::raw(mode_abbrev(entry.permission_mode.as_deref()).to_string()),
         ]),
         Line::from(vec![
             Span::styled("Started:    ", Style::default().fg(theme.muted)),
@@ -394,7 +413,7 @@ fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) 
 const TTL_BAR_WIDTH: usize = 8;
 
 /// Height of the Sessions-mode detail panel (includes 2 border rows).
-const SESSION_DETAIL_HEIGHT: u16 = 8;
+const SESSION_DETAIL_HEIGHT: u16 = 9;
 
 /// Max width the Project column renders before middle-truncating.
 const PROJECT_NAME_MAX_WIDTH: usize = 22;
@@ -438,6 +457,28 @@ pub(crate) fn render_ttl_cell(remaining_secs: i64, theme: &Theme) -> Cell<'stati
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mode_abbrev_maps_accept_edits_to_accept() {
+        assert_eq!(mode_abbrev(Some("acceptEdits")), "accept");
+    }
+
+    #[test]
+    fn mode_abbrev_passes_through_known_short_values() {
+        assert_eq!(mode_abbrev(Some("auto")), "auto");
+        assert_eq!(mode_abbrev(Some("default")), "default");
+        assert_eq!(mode_abbrev(Some("plan")), "plan");
+    }
+
+    #[test]
+    fn mode_abbrev_falls_back_to_other_for_unknown() {
+        assert_eq!(mode_abbrev(Some("bypassPermissions")), "other");
+    }
+
+    #[test]
+    fn mode_abbrev_returns_dash_for_none() {
+        assert_eq!(mode_abbrev(None), "—");
+    }
 
     #[test]
     fn ttl_cell_expired_has_em_dash() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -105,7 +105,13 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
     }
 
     let header = Row::new(vec![
-        "", "ID", "Project", "Mode", "Last", "Cache TTL", "Size",
+        "",
+        "ID",
+        "Project",
+        "Mode",
+        "Last",
+        "Cache TTL",
+        "Size",
     ])
     .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
     .bottom_margin(1);

--- a/tests/hook_scripts.rs
+++ b/tests/hook_scripts.rs
@@ -156,6 +156,39 @@ fn session_end_marks_terminated() {
 }
 
 #[test]
+fn user_prompt_creates_entry_when_session_start_was_missed() {
+    if !jq_present() {
+        return;
+    }
+    // Simulate the situation where SessionStart didn't fire for this session
+    // (e.g., `claude --resume` before duru's hooks had time to handle it, or
+    // `~/.claude/duru/registry/` simply didn't exist yet). The heartbeat
+    // script must mkdir -p and create the entry.
+    let tmp = tempfile::tempdir().unwrap();
+    // Note: no `mkdir -p .claude/duru/registry` here — script must create it.
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let prompt_sh = install_script(&scripts_dir, "user-prompt-submit.sh", USER_PROMPT);
+
+    let payload = r#"{
+        "session_id": "fresh-resume",
+        "cwd": "/tmp",
+        "transcript_path": "/tmp/fr.jsonl",
+        "permission_mode": "auto",
+        "prompt": "hi"
+    }"#;
+    run_hook(&prompt_sh, payload, tmp.path());
+
+    let path = tmp.path().join(".claude/duru/registry/fresh-resume.json");
+    assert!(
+        path.exists(),
+        "heartbeat must create registry file if missing"
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(parsed["session_id"], "fresh-resume");
+    assert_eq!(parsed["permission_mode"], "auto");
+}
+
+#[test]
 fn hook_exit_zero_on_malformed_stdin() {
     if !jq_present() {
         return;

--- a/tests/hook_scripts.rs
+++ b/tests/hook_scripts.rs
@@ -1,0 +1,168 @@
+//! Integration tests for the embedded hook shell scripts. Each test spawns
+//! `bash` with one of the scripts and a synthetic JSON payload on stdin, then
+//! asserts the resulting registry file shape.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn jq_present() -> bool {
+    Command::new("jq")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn install_script(tmp: &tempfile::TempDir, filename: &str, content: &str) -> std::path::PathBuf {
+    let path = tmp.path().join(filename);
+    std::fs::write(&path, content).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+fn run_hook(script_path: &std::path::Path, stdin_json: &str, home: &std::path::Path) {
+    let mut child = Command::new("bash")
+        .arg(script_path)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin_json.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert!(
+        out.status.success(),
+        "hook exit non-zero: stderr = {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn fake_home() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude/duru/registry")).unwrap();
+    tmp
+}
+
+const SESSION_START: &str = include_str!("../src/_hook_scripts/session-start.sh");
+const USER_PROMPT: &str = include_str!("../src/_hook_scripts/user-prompt-submit.sh");
+const SESSION_END: &str = include_str!("../src/_hook_scripts/session-end.sh");
+
+#[test]
+fn session_start_creates_registry_entry() {
+    if !jq_present() {
+        eprintln!("jq not found, skipping");
+        return;
+    }
+    let home = fake_home();
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let script = install_script(&scripts_dir, "session-start.sh", SESSION_START);
+
+    let payload = r#"{
+        "session_id": "test-session",
+        "cwd": "/tmp/work",
+        "transcript_path": "/tmp/work/t.jsonl",
+        "source": "startup",
+        "permission_mode": "",
+        "hook_event_name": "SessionStart"
+    }"#;
+    run_hook(&script, payload, home.path());
+
+    let path = home.path().join(".claude/duru/registry/test-session.json");
+    assert!(path.exists(), "registry file should exist");
+    let content = std::fs::read_to_string(&path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(parsed["session_id"], "test-session");
+    assert_eq!(parsed["terminated"], false);
+    assert_eq!(parsed["cwd"], "/tmp/work");
+}
+
+#[test]
+fn user_prompt_updates_heartbeat_preserves_other_fields() {
+    if !jq_present() {
+        return;
+    }
+    let home = fake_home();
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let start_sh = install_script(&scripts_dir, "session-start.sh", SESSION_START);
+    let prompt_sh = install_script(&scripts_dir, "user-prompt-submit.sh", USER_PROMPT);
+
+    let start_payload = r#"{
+        "session_id": "heartbeat-test",
+        "cwd": "/tmp",
+        "transcript_path": "/tmp/h.jsonl",
+        "source": "startup"
+    }"#;
+    run_hook(&start_sh, start_payload, home.path());
+    let path = home.path().join(".claude/duru/registry/heartbeat-test.json");
+    let before: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    let started = before["started_at"].clone();
+    let pid = before["pid"].clone();
+
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let prompt_payload = r#"{
+        "session_id": "heartbeat-test",
+        "cwd": "/tmp",
+        "transcript_path": "/tmp/h.jsonl",
+        "permission_mode": "auto",
+        "prompt": "hi"
+    }"#;
+    run_hook(&prompt_sh, prompt_payload, home.path());
+
+    let after: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(after["started_at"], started, "started_at must not change");
+    assert_eq!(after["pid"], pid, "pid must not change");
+    assert_eq!(after["permission_mode"], "auto");
+    assert_ne!(after["last_heartbeat"], started);
+}
+
+#[test]
+fn session_end_marks_terminated() {
+    if !jq_present() {
+        return;
+    }
+    let home = fake_home();
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let start_sh = install_script(&scripts_dir, "session-start.sh", SESSION_START);
+    let end_sh = install_script(&scripts_dir, "session-end.sh", SESSION_END);
+
+    let start_payload = r#"{
+        "session_id": "end-test",
+        "cwd": "/tmp",
+        "transcript_path": "/tmp/e.jsonl",
+        "source": "startup"
+    }"#;
+    run_hook(&start_sh, start_payload, home.path());
+
+    let end_payload = r#"{"session_id":"end-test","reason":"exit"}"#;
+    run_hook(&end_sh, end_payload, home.path());
+
+    let path = home.path().join(".claude/duru/registry/end-test.json");
+    let parsed: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(parsed["terminated"], true);
+    assert_eq!(parsed["end_reason"], "exit");
+}
+
+#[test]
+fn hook_exit_zero_on_malformed_stdin() {
+    if !jq_present() {
+        return;
+    }
+    let home = fake_home();
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let start_sh = install_script(&scripts_dir, "session-start.sh", SESSION_START);
+
+    // Not JSON at all. Hook must still exit 0 (run_hook's assert).
+    run_hook(&start_sh, "not json", home.path());
+}

--- a/tests/hook_scripts.rs
+++ b/tests/hook_scripts.rs
@@ -103,9 +103,10 @@ fn user_prompt_updates_heartbeat_preserves_other_fields() {
         "source": "startup"
     }"#;
     run_hook(&start_sh, start_payload, home.path());
-    let path = home.path().join(".claude/duru/registry/heartbeat-test.json");
-    let before: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    let path = home
+        .path()
+        .join(".claude/duru/registry/heartbeat-test.json");
+    let before: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
     let started = before["started_at"].clone();
     let pid = before["pid"].clone();
 


### PR DESCRIPTION
## Summary

- Adds `duru hooks install/uninstall/status` subcommands — idempotent merge/remove of six Claude Code hooks in `~/.claude/settings.json`, preserving unrelated hooks via dual identification (`_duru: true` marker OR command path).
- New `src/registry.rs` reads per-session JSON state written by the hooks. `SessionCache::refresh` merges it to show accurate permission mode, real `/exit` detection via `SessionEnd`, PID-based liveness via `libc::kill(pid, 0)`, and `/clear` disambiguation via same-pid dedup with pid-reuse guard.
- Mode column returns to the Sessions table now that the value is trustworthy; `—` when hooks not installed.
- Registry entries are pruned 7 days after `ended_at`.
- Consent-gated GitHub star prompt at end of `duru hooks install` (k-skill pattern).
- Hook-absent code path preserves MVP1 behavior entirely; all existing tests pass unchanged.

## Usage

~~~bash
duru hooks install       # interactive, requires jq
duru hooks install --dry-run
duru hooks install --yes --star
duru hooks status
duru hooks uninstall
duru hooks uninstall --force   # also removes ~/.claude/duru/
~~~

## Architecture

Event flow:

~~~
Claude Code event
  ↓
~/.claude/settings.json  ──  hooks registered by `duru hooks install`
  ↓  command: bash ~/.claude/duru/hooks/<event>.sh
bash hook script (reads JSON stdin via jq, atomic write via mktemp+mv)
  ↓
~/.claude/duru/registry/<session_id>.json
  ↓
Registry::load_all()  on every SessionCache refresh
  ↓  merged by transcript_path; registry authoritative where present; mtime fallback elsewhere
SessionEntry (with permission_mode, registry_source, is_alive)
~~~

Six events subscribed: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd. Pre/PostToolUse are heartbeats during tool loops — each maps to an actual API round-trip that refreshes the server-side cache TTL.

## Test plan

- [x] `cargo test` — 178 unit + 4 integration = 182 pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `duru hooks install --dry-run` prints plan, no changes
- [x] `duru hooks status` on fresh install reports "not installed"
- [ ] Manual: real `claude` session with hooks installed fires registry entries; `/exit` marks terminated
- [ ] Manual: `claude --resume` fires SessionStart with `source: "resume"` per docs

Spec: `docs/superpowers/specs/2026-04-20-sessions-hooks-design.md` (gitignored local)
Plan: `docs/superpowers/plans/2026-04-20-sessions-hooks.md` (gitignored local)