### PR TITLE
fix: cfg-gate Unix-only APIs for Windows build (v0.3.0 hotfix)

### DIFF
--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -61,6 +61,20 @@ pub fn check_jq_available() -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
+/// Set mode 0o755 on Unix; no-op on Windows (NTFS uses ACLs, not POSIX bits).
+#[cfg(unix)]
+fn chmod_executable(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms)
+}
+
+#[cfg(not(unix))]
+fn chmod_executable(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
 pub fn install(home: &Path, opts: &InstallOpts) -> std::io::Result<()> {
     if !check_jq_available() {
         eprintln!("error: `jq` is required but not found on PATH.");
@@ -87,10 +101,7 @@ pub fn install(home: &Path, opts: &InstallOpts) -> std::io::Result<()> {
     for (name, content) in hook_scripts::all() {
         let path = hooks_dir(home).join(name);
         fs::write(&path, content)?;
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&path)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms)?;
+        chmod_executable(&path)?;
     }
 
     merge_settings(home)?;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -408,10 +408,20 @@ mod tests {
         assert_eq!(classify(&entry), RegistrySource::Terminated);
     }
 
+    #[cfg(unix)]
     #[test]
     fn classify_dead_pid_is_terminated() {
         let entry = sample_entry(30, false, Some(4_000_000));
         assert_eq!(classify(&entry), RegistrySource::Terminated);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn classify_treats_any_pid_as_alive_on_non_unix() {
+        // Documented behavior: is_pid_alive is conservative on non-Unix,
+        // so classify cannot contribute a Terminated verdict from pid alone.
+        let entry = sample_entry(30, false, Some(4_000_000));
+        assert_eq!(classify(&entry), RegistrySource::Alive);
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -157,8 +157,12 @@ pub fn classify(entry: &RegistryEntry) -> RegistrySource {
 }
 
 /// Returns true if a process with `pid` currently exists.
-/// Uses `kill(pid, 0)` — zero signal means "check only, don't deliver".
+/// On Unix uses `kill(pid, 0)` — zero signal means "check only, don't deliver".
 /// `EPERM` (process exists but not ours to signal) also counts as alive.
+/// On Windows we cannot check from bash hooks (the captured pid is the bash
+/// shell's parent, which does not map cleanly); return `true` so the registry
+/// entry falls back to the mtime-based liveness instead.
+#[cfg(unix)]
 pub fn is_pid_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
@@ -172,24 +176,43 @@ pub fn is_pid_alive(pid: u32) -> bool {
     err == Some(libc::EPERM)
 }
 
+#[cfg(not(unix))]
+pub fn is_pid_alive(_pid: u32) -> bool {
+    // Conservative default: we cannot prove death on this platform without
+    // extra APIs we have chosen not to depend on. Callers fall through to
+    // the mtime-based liveness check, which is the MVP1 behavior.
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn is_pid_alive_returns_true_for_current_process() {
         let own_pid = std::process::id();
         assert!(is_pid_alive(own_pid));
     }
 
+    #[cfg(unix)]
     #[test]
     fn is_pid_alive_returns_false_for_impossible_pid() {
         assert!(!is_pid_alive(4_000_000));
     }
 
+    #[cfg(unix)]
     #[test]
     fn is_pid_alive_for_zero_returns_false() {
         assert!(!is_pid_alive(0));
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn is_pid_alive_returns_true_on_non_unix() {
+        // Conservative default; documented in is_pid_alive doc comment.
+        assert!(is_pid_alive(std::process::id()));
+        assert!(is_pid_alive(4_000_000));
     }
 
     use std::io::Write;


### PR DESCRIPTION
## Summary

The v0.3.0 release workflow failed on Windows because MVP2 (PR #14) added two Unix-only code paths without cfg gates:

1. \`registry::is_pid_alive\` used \`libc::kill\` / \`libc::EPERM\` / \`libc::pid_t\` directly.
2. \`hooks_install\` chmod'd hook scripts via \`std::os::unix::fs::PermissionsExt::set_mode\`.

## Fix

- \`is_pid_alive\`: \`#[cfg(unix)]\` keeps the libc impl; \`#[cfg(not(unix))]\` returns \`true\` (conservative — can't prove death without extra deps we chose to avoid). The mtime fallback handles Windows liveness.
- \`hook_scripts\` chmod: factored into \`chmod_executable\` with \`cfg(unix)\` doing the POSIX chmod and \`cfg(not(unix))\` being a no-op.

## Test plan

- [x] \`cargo build\` clean locally (macOS)
- [x] \`cargo test\` 185 passing locally
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI passes on all 6 release targets (aarch64/x86_64 × macOS/Linux/Windows)

## After merge

After merge, delete the failed \`v0.3.0\` tag remotely and re-tag from the new main head:

\`\`\`bash
git push --delete origin v0.3.0
gh release delete v0.3.0 --yes --cleanup-tag
# then from main after merge:
git tag -a v0.3.0 -m "v0.3.0"
git push origin v0.3.0
\`\`\`