### PR TITLE
fix: use gh api PUT for starring instead of non-existent subcommand

### DIFF
--- a/src/hooks_install.rs
+++ b/src/hooks_install.rs
@@ -238,18 +238,24 @@ fn try_star() {
         .unwrap_or(false);
     if !auth_ok {
         println!("gh is installed but not authenticated. Run `gh auth login`,");
-        println!("then: gh repo star uppinote20/duru");
+        println!("then star manually at https://github.com/uppinote20/duru");
         return;
     }
     let star_ok = Command::new("gh")
-        .args(["repo", "star", "uppinote20/duru"])
-        .status()
-        .map(|s| s.success())
+        .args([
+            "api",
+            "--method",
+            "PUT",
+            "--silent",
+            "/user/starred/uppinote20/duru",
+        ])
+        .output()
+        .map(|o| o.status.success())
         .unwrap_or(false);
     if star_ok {
         println!("★ Thanks!");
     } else {
-        println!("  (gh repo star failed — star manually at https://github.com/uppinote20/duru)");
+        println!("  (star failed — star manually at https://github.com/uppinote20/duru)");
     }
 }
 


### PR DESCRIPTION
## Summary
- `duru hooks install` consent flow tried to call `gh repo star <owner>/<repo>`, but `gh` has no `star` subcommand under `gh repo`, so the star step always failed with `unknown command "star" for "gh repo"`.
- Switched to the documented REST endpoint `PUT /user/starred/{owner}/{repo}` via `gh api --method PUT --silent`, which is the only gh-native way to star a repo.
- Replaced `.status()` with `.output()` so `gh`'s failure output no longer leaks past our own fallback message.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (180 + 5 passing)
- [x] Manually verified `gh api --method PUT --silent /user/starred/uppinote20/duru` returns success (204) against an authenticated gh session.