### PR TITLE
chore: scope libc dependency to cfg(unix) targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ pulldown-cmark = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Move `libc = "0.2"` from top-level `[dependencies]` to `[target.'cfg(unix)'.dependencies]`
- `libc` is only consumed by `registry::is_pid_alive` (cfg-gated to `unix` since #24)
- Windows builds no longer pull `libc` into the dependency graph

## Changes
- `Cargo.toml`: 2 lines added (target table + move `libc` under it)

## Verification
- `cargo build` ✓ (macOS)
- `cargo test` ✓ (185 tests pass)
- `cargo metadata --filter-platform x86_64-pc-windows-msvc` → 0 `libc` packages
- `cargo metadata --filter-platform x86_64-apple-darwin` → 1 `libc` package

## Test plan
- [x] cargo build passes locally
- [x] cargo test passes (185/185)
- [x] Windows metadata filter excludes libc
- [x] Unix metadata filter still includes libc
- [ ] CI green on all six release targets

Closes #25