### PR TITLE
feat(theme): replace COLORFGBG heuristic with terminal-colorsaurus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "terminal-colorsaurus",
 ]
 
 [[package]]
@@ -896,6 +897,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-colorsaurus"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46bb5364467da040298c573c8a95dbf9a512efc039630409a03126e3703e90"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio",
+ "terminal-trx",
+ "windows-sys 0.61.2",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3f27d9a8a177e57545481faec87acb45c6e854ed1e5a3658ad186c106f38ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1348,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 libc = "0.2"
+terminal-colorsaurus = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -67,16 +67,15 @@ impl Theme {
     }
 
     fn detect() -> Self {
-        // Check COLORFGBG env var: "foreground;background"
-        // Background >= 8 usually means light theme
-        if let Ok(val) = std::env::var("COLORFGBG")
-            && let Some(bg) = val.rsplit(';').next()
-            && let Ok(bg_num) = bg.parse::<u8>()
-            && bg_num >= 8
-        {
-            return Self::light();
+        // OSC 10/11 query covers modern terminals (Alacritty, Kitty, WezTerm,
+        // Ghostty, foot, GNOME/VTE, Terminal.app) where COLORFGBG is unset.
+        // Falls back to Dark on detection failure (no TTY, query timeout,
+        // unsupported terminal) — matches the prior behavior.
+        use terminal_colorsaurus::{QueryOptions, ThemeMode as Detected, theme_mode};
+        match theme_mode(QueryOptions::default()) {
+            Ok(Detected::Light) => Self::light(),
+            Ok(Detected::Dark) | Err(_) => Self::dark(),
         }
-        Self::dark()
     }
 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,5 @@
 use ratatui::style::Color;
+use terminal_colorsaurus::{QueryOptions, ThemeMode as DetectedThemeMode, theme_mode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeMode {
@@ -67,14 +68,10 @@ impl Theme {
     }
 
     fn detect() -> Self {
-        // OSC 10/11 query covers modern terminals (Alacritty, Kitty, WezTerm,
-        // Ghostty, foot, GNOME/VTE, Terminal.app) where COLORFGBG is unset.
-        // Falls back to Dark on detection failure (no TTY, query timeout,
-        // unsupported terminal) — matches the prior behavior.
-        use terminal_colorsaurus::{QueryOptions, ThemeMode as Detected, theme_mode};
+        // OSC 10/11 query; falls back to Dark if no TTY or unsupported terminal.
         match theme_mode(QueryOptions::default()) {
-            Ok(Detected::Light) => Self::light(),
-            Ok(Detected::Dark) | Err(_) => Self::dark(),
+            Ok(DetectedThemeMode::Light) => Self::light(),
+            Ok(DetectedThemeMode::Dark) | Err(_) => Self::dark(),
         }
     }
 }
@@ -104,5 +101,13 @@ mod tests {
 
         let light = Theme::from_option(Some("light"));
         assert_eq!(light.mode, ThemeMode::Light);
+    }
+
+    #[test]
+    fn from_option_none_does_not_panic() {
+        // Smoke test: detection runs in test harness with no TTY; we don't
+        // assert which mode wins, only that the call returns a valid Theme.
+        let theme = Theme::from_option(None);
+        assert!(matches!(theme.mode, ThemeMode::Dark | ThemeMode::Light));
     }
 }


### PR DESCRIPTION
## Summary
- Replace the 12-line `COLORFGBG`-based heuristic in `Theme::detect()` with a single `terminal_colorsaurus::theme_mode()` call.
- Add `terminal-colorsaurus = "1"` (v1.0.3, 2M+ downloads, used by `bat`/`delta`).
- Coverage now includes Alacritty, Kitty, WezTerm, Ghostty, foot, GNOME/VTE, Terminal.app — the modern terminals that don't set `COLORFGBG` (where the previous code always fell through to Dark).

## Changes
- `Cargo.toml`: add `terminal-colorsaurus = "1"`
- `src/theme.rs`: rewrite `detect()` body; keep `from_option`, `dark`, `light`, all existing tests untouched.
- `Cargo.lock`: 3 transitive deps added (`terminal-colorsaurus`, `terminal-trx`, `xterm-color`).

## Behavior preserved
- `--theme dark` / `--theme light` overrides unchanged.
- Detection failure (no TTY, query timeout, unsupported terminal) falls back to **Dark** — same as before.

## Verification
- `cargo build` ✓
- `cargo test` ✓ (185/185)
- `cargo clippy --all-targets` ✓ clean
- `cargo run -- --help` ✓
- `cargo run -- --theme light --help` ✓

## Test plan
- [x] cargo test passes
- [x] cargo clippy clean
- [ ] Manual QA: dark terminal → dark theme
- [ ] Manual QA: light terminal → light theme
- [ ] Manual QA: \`--theme light\` override forces light regardless

Closes #7