### PR TITLE
feat(sessions): sort direction toggle + hook PPID docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ Press `Tab` to switch between two modes:
 | `jk` / `↑↓` | Navigate rows (Table) / scroll (Detail) |
 | `hl` / `←→` | Toggle Table / Detail focus |
 | `s` | Cycle sort (activity → TTL → project → size) |
+| `S` | Reverse sort direction (toggle asc/desc) |
 | `r` | Force refresh |
 | `g` `G` | Jump to top / bottom |
 | `Tab` | Switch to Memory mode |
 | `q` | Quit |
+
+The active sort column shows a direction arrow in the table header: `↓` for descending (the default for activity and size), `↑` for ascending (the default for cache TTL and project). Press `S` to flip the current column's direction.
 
 ## Layout
 

--- a/src/_hook_scripts/session-start.sh
+++ b/src/_hook_scripts/session-start.sh
@@ -10,6 +10,8 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
 MODE=$(echo "$INPUT" | jq -r '.permission_mode // empty')
+# $PPID here maps directly to the long-running `claude` process — Claude
+# Code invokes hooks via exec, not via an intermediary shell. Verified in #16.
 PID_VAL="${PPID:-0}"
 
 TMP=$(mktemp "${REGISTRY}.XXXXXX")

--- a/src/_hook_scripts/user-prompt-submit.sh
+++ b/src/_hook_scripts/user-prompt-submit.sh
@@ -18,6 +18,7 @@ if [ -f "$REGISTRY" ]; then
 else
   CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
   TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+  # PPID rationale: see session-start.sh / issue #16.
   jq -n --arg sid "$SESSION_ID" --arg hb "$NOW" --arg mode "$MODE" \
         --arg cwd "$CWD" --arg tr "$TRANSCRIPT" --argjson pid "${PPID:-0}" \
     '{schema_version:1, session_id:$sid, pid:$pid, cwd:$cwd,

--- a/src/app.rs
+++ b/src/app.rs
@@ -166,8 +166,14 @@ impl App {
                     self.session_scroll = 0;
                 }
             }
-            KeyCode::Char('s') => self.cycle_sort(),
-            KeyCode::Char('S') => self.sort_reverse = !self.sort_reverse,
+            KeyCode::Char('s') => {
+                self.cycle_sort();
+                self.wants_refresh = true;
+            }
+            KeyCode::Char('S') => {
+                self.sort_reverse = !self.sort_reverse;
+                self.wants_refresh = true;
+            }
             KeyCode::Char('r') => self.wants_refresh = true,
             _ => {}
         }
@@ -552,6 +558,26 @@ mod tests {
         assert!(app.sort_reverse);
         app.handle_key(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT));
         assert!(!app.sort_reverse);
+    }
+
+    #[test]
+    fn sessions_mode_shift_s_requests_immediate_refresh() {
+        // The header arrow flips on the next render, so the table rows must
+        // be re-sorted the same tick — not up to `FAST_POLL_MS` later.
+        let mut app = app_in_sessions_mode();
+        assert!(!app.wants_refresh);
+        app.handle_key(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT));
+        assert!(app.wants_refresh);
+    }
+
+    #[test]
+    fn sessions_mode_s_requests_immediate_refresh() {
+        // Same rationale as `S`: the active-column indicator moves on render,
+        // rows must re-sort the same tick.
+        let mut app = app_in_sessions_mode();
+        assert!(!app.wants_refresh);
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert!(app.wants_refresh);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,6 +57,7 @@ pub struct App {
     pub session_scroll: u16,
     pub sessions_focus: SessionsPane,
     pub sessions_sort: SessionsSort,
+    pub sort_reverse: bool,
     pub last_refresh: Instant,
     pub wants_refresh: bool,
     pub skip_real_refresh: bool,
@@ -81,6 +82,7 @@ impl App {
             session_scroll: 0,
             sessions_focus: SessionsPane::Table,
             sessions_sort: SessionsSort::default(),
+            sort_reverse: false,
             last_refresh: Instant::now(),
             wants_refresh: false,
             skip_real_refresh: false,
@@ -165,6 +167,7 @@ impl App {
                 }
             }
             KeyCode::Char('s') => self.cycle_sort(),
+            KeyCode::Char('S') => self.sort_reverse = !self.sort_reverse,
             KeyCode::Char('r') => self.wants_refresh = true,
             _ => {}
         }
@@ -191,7 +194,12 @@ impl App {
         use crate::sessions::sort_entries;
         self.session_cache.refresh(claude_dir);
         let mut entries = self.session_cache.entries();
-        sort_entries(&mut entries, self.sessions_sort, chrono::Utc::now());
+        sort_entries(
+            &mut entries,
+            self.sessions_sort,
+            self.sort_reverse,
+            chrono::Utc::now(),
+        );
         self.sessions = entries;
         self.clamp_session_index();
         self.last_refresh = Instant::now();
@@ -534,6 +542,25 @@ mod tests {
         assert_eq!(app.sessions_sort, SessionsSort::Size);
         app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
         assert_eq!(app.sessions_sort, SessionsSort::LastActivity);
+    }
+
+    #[test]
+    fn sessions_mode_shift_s_toggles_sort_reverse() {
+        let mut app = app_in_sessions_mode();
+        assert!(!app.sort_reverse);
+        app.handle_key(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT));
+        assert!(app.sort_reverse);
+        app.handle_key(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT));
+        assert!(!app.sort_reverse);
+    }
+
+    #[test]
+    fn sessions_mode_s_preserves_sort_reverse() {
+        let mut app = app_in_sessions_mode();
+        app.sort_reverse = true;
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.sessions_sort, SessionsSort::CacheTtl);
+        assert!(app.sort_reverse, "cycling sort must not clear the reverse flag");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -560,7 +560,10 @@ mod tests {
         app.sort_reverse = true;
         app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
         assert_eq!(app.sessions_sort, SessionsSort::CacheTtl);
-        assert!(app.sort_reverse, "cycling sort must not clear the reverse flag");
+        assert!(
+            app.sort_reverse,
+            "cycling sort must not clear the reverse flag"
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1191,6 +1191,7 @@ mod tests {
     fn sort_cache_ttl_reverse_still_pushes_expired_to_bottom() {
         let now = Utc::now();
         let mut entries = vec![
+            make_entry("expired_old", now - chrono::Duration::hours(3)),
             make_entry("expired_recent", now - chrono::Duration::seconds(400)),
             make_entry("fresh", now - chrono::Duration::seconds(10)),
             make_entry("expiring_soon", now - chrono::Duration::seconds(290)),
@@ -1199,7 +1200,9 @@ mod tests {
         // Warm entries reversed (fresh first), expired still at bottom.
         assert_eq!(entries[0].session_id, "fresh");
         assert_eq!(entries[1].session_id, "expiring_soon");
+        // Expired bucket ordering is independent of direction flag.
         assert_eq!(entries[2].session_id, "expired_recent");
+        assert_eq!(entries[3].session_id, "expired_old");
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -546,7 +546,11 @@ pub fn sort_entries(
         }
         SessionsSort::Project => {
             entries.sort_by(|a, b| {
-                order(a.project_name.to_lowercase().cmp(&b.project_name.to_lowercase()))
+                order(
+                    a.project_name
+                        .to_lowercase()
+                        .cmp(&b.project_name.to_lowercase()),
+                )
             });
         }
         SessionsSort::Size => {
@@ -1125,9 +1129,18 @@ mod tests {
 
     #[test]
     fn sessions_sort_default_direction_per_field() {
-        assert_eq!(SessionsSort::LastActivity.default_direction(), SortDirection::Desc);
-        assert_eq!(SessionsSort::CacheTtl.default_direction(), SortDirection::Asc);
-        assert_eq!(SessionsSort::Project.default_direction(), SortDirection::Asc);
+        assert_eq!(
+            SessionsSort::LastActivity.default_direction(),
+            SortDirection::Desc
+        );
+        assert_eq!(
+            SessionsSort::CacheTtl.default_direction(),
+            SortDirection::Asc
+        );
+        assert_eq!(
+            SessionsSort::Project.default_direction(),
+            SortDirection::Asc
+        );
         assert_eq!(SessionsSort::Size.default_direction(), SortDirection::Desc);
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -43,6 +43,37 @@ pub enum SessionsSort {
     Size,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SessionsSort {
+    /// Natural direction for each field. `LastActivity` and `Size` default to
+    /// Desc (newest/largest first); `CacheTtl` defaults to Asc so sessions
+    /// closest to cache expiry surface at the top ("needs attention" order);
+    /// `Project` defaults to Asc for alphabetical scanning.
+    pub fn default_direction(self) -> SortDirection {
+        match self {
+            SessionsSort::LastActivity => SortDirection::Desc,
+            SessionsSort::CacheTtl => SortDirection::Asc,
+            SessionsSort::Project => SortDirection::Asc,
+            SessionsSort::Size => SortDirection::Desc,
+        }
+    }
+
+    /// Effective direction given a reverse flag. `reverse=false` returns the
+    /// default; `reverse=true` flips it.
+    pub fn effective_direction(self, reverse: bool) -> SortDirection {
+        match (self.default_direction(), reverse) {
+            (d, false) => d,
+            (SortDirection::Asc, true) => SortDirection::Desc,
+            (SortDirection::Desc, true) => SortDirection::Asc,
+        }
+    }
+}
+
 pub fn short_id(uuid: &str) -> String {
     uuid.chars().take(SHORT_ID_LEN).collect()
 }
@@ -477,22 +508,49 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
     ]
 }
 
-pub fn sort_entries(entries: &mut [SessionEntry], sort: SessionsSort, now: DateTime<Utc>) {
+/// Sort `entries` in place by the given field. `reverse` flips each field's
+/// natural direction (see `SessionsSort::default_direction`) — useful for
+/// "oldest first" or "smallest first" views that the defaults don't cover.
+pub fn sort_entries(
+    entries: &mut [SessionEntry],
+    sort: SessionsSort,
+    reverse: bool,
+    now: DateTime<Utc>,
+) {
+    let direction = sort.effective_direction(reverse);
+    let order = |ord: std::cmp::Ordering| match direction {
+        SortDirection::Asc => ord,
+        SortDirection::Desc => ord.reverse(),
+    };
     match sort {
         SessionsSort::LastActivity => {
-            entries.sort_by_key(|e| std::cmp::Reverse(e.last_activity));
+            entries.sort_by(|a, b| order(a.last_activity.cmp(&b.last_activity)));
         }
         SessionsSort::CacheTtl => {
-            // Ascending on purpose: sessions closest to expiry come first
-            // ("needs attention" order). Do not "fix" to Reverse — that
-            // would hide the sessions a user cares most about at the bottom.
-            entries.sort_by_key(|e| cache_ttl_remaining_secs(e, now));
+            // Expired entries (remaining == 0) collapse to the same value, so
+            // they'd clump at the top of Asc ("needs attention") despite being
+            // the opposite of what the user wants. Bucket them: warm entries
+            // first (sorted by direction), expired entries always at the
+            // bottom (tie-broken by last_activity desc — most-recently expired
+            // first, which is the more useful ordering).
+            entries.sort_by(|a, b| {
+                let ra = cache_ttl_remaining_secs(a, now);
+                let rb = cache_ttl_remaining_secs(b, now);
+                match (ra == 0, rb == 0) {
+                    (false, false) => order(ra.cmp(&rb)),
+                    (false, true) => std::cmp::Ordering::Less,
+                    (true, false) => std::cmp::Ordering::Greater,
+                    (true, true) => b.last_activity.cmp(&a.last_activity),
+                }
+            });
         }
         SessionsSort::Project => {
-            entries.sort_by_key(|e| e.project_name.to_lowercase());
+            entries.sort_by(|a, b| {
+                order(a.project_name.to_lowercase().cmp(&b.project_name.to_lowercase()))
+            });
         }
         SessionsSort::Size => {
-            entries.sort_by_key(|e| std::cmp::Reverse(e.file_size));
+            entries.sort_by(|a, b| order(a.file_size.cmp(&b.file_size)));
         }
     }
 }
@@ -793,7 +851,7 @@ mod tests {
             make_entry("new", now - chrono::Duration::seconds(5)),
             make_entry("mid", now - chrono::Duration::minutes(2)),
         ];
-        sort_entries(&mut entries, SessionsSort::LastActivity, now);
+        sort_entries(&mut entries, SessionsSort::LastActivity, false, now);
         assert_eq!(entries[0].session_id, "new");
         assert_eq!(entries[1].session_id, "mid");
         assert_eq!(entries[2].session_id, "old");
@@ -807,7 +865,7 @@ mod tests {
             make_entry("expiring", now - chrono::Duration::seconds(270)),
             make_entry("middle", now - chrono::Duration::seconds(120)),
         ];
-        sort_entries(&mut entries, SessionsSort::CacheTtl, now);
+        sort_entries(&mut entries, SessionsSort::CacheTtl, false, now);
         assert_eq!(entries[0].session_id, "expiring");
         assert_eq!(entries[1].session_id, "middle");
         assert_eq!(entries[2].session_id, "fresh");
@@ -821,7 +879,7 @@ mod tests {
             make_entry("a", now),
             make_entry("b", now),
         ];
-        sort_entries(&mut entries, SessionsSort::Project, now);
+        sort_entries(&mut entries, SessionsSort::Project, false, now);
         assert_eq!(entries[0].session_id, "a");
         assert_eq!(entries[2].session_id, "c");
     }
@@ -1059,9 +1117,96 @@ mod tests {
         entries[0].file_size = 100;
         entries[1].file_size = 10_000;
         entries[2].file_size = 1_000;
-        sort_entries(&mut entries, SessionsSort::Size, now);
+        sort_entries(&mut entries, SessionsSort::Size, false, now);
         assert_eq!(entries[0].session_id, "big");
         assert_eq!(entries[1].session_id, "mid");
         assert_eq!(entries[2].session_id, "small");
+    }
+
+    #[test]
+    fn sessions_sort_default_direction_per_field() {
+        assert_eq!(SessionsSort::LastActivity.default_direction(), SortDirection::Desc);
+        assert_eq!(SessionsSort::CacheTtl.default_direction(), SortDirection::Asc);
+        assert_eq!(SessionsSort::Project.default_direction(), SortDirection::Asc);
+        assert_eq!(SessionsSort::Size.default_direction(), SortDirection::Desc);
+    }
+
+    #[test]
+    fn sort_last_activity_reverse_puts_oldest_first() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("new", now - chrono::Duration::seconds(5)),
+            make_entry("old", now - chrono::Duration::minutes(10)),
+            make_entry("mid", now - chrono::Duration::minutes(2)),
+        ];
+        sort_entries(&mut entries, SessionsSort::LastActivity, true, now);
+        assert_eq!(entries[0].session_id, "old");
+        assert_eq!(entries[2].session_id, "new");
+    }
+
+    #[test]
+    fn sort_cache_ttl_reverse_puts_freshest_first() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("fresh", now - chrono::Duration::seconds(10)),
+            make_entry("expiring", now - chrono::Duration::seconds(270)),
+        ];
+        sort_entries(&mut entries, SessionsSort::CacheTtl, true, now);
+        assert_eq!(entries[0].session_id, "fresh");
+        assert_eq!(entries[1].session_id, "expiring");
+    }
+
+    #[test]
+    fn sort_cache_ttl_asc_pushes_expired_to_bottom() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("expired_old", now - chrono::Duration::hours(3)),
+            make_entry("expiring_soon", now - chrono::Duration::seconds(290)),
+            make_entry("expired_recent", now - chrono::Duration::seconds(400)),
+            make_entry("fresh", now - chrono::Duration::seconds(10)),
+        ];
+        sort_entries(&mut entries, SessionsSort::CacheTtl, false, now);
+        // Warm entries first, Asc (expiring-soonest → freshest).
+        assert_eq!(entries[0].session_id, "expiring_soon");
+        assert_eq!(entries[1].session_id, "fresh");
+        // Expired entries at the bottom, most-recently expired first.
+        assert_eq!(entries[2].session_id, "expired_recent");
+        assert_eq!(entries[3].session_id, "expired_old");
+    }
+
+    #[test]
+    fn sort_cache_ttl_reverse_still_pushes_expired_to_bottom() {
+        let now = Utc::now();
+        let mut entries = vec![
+            make_entry("expired_recent", now - chrono::Duration::seconds(400)),
+            make_entry("fresh", now - chrono::Duration::seconds(10)),
+            make_entry("expiring_soon", now - chrono::Duration::seconds(290)),
+        ];
+        sort_entries(&mut entries, SessionsSort::CacheTtl, true, now);
+        // Warm entries reversed (fresh first), expired still at bottom.
+        assert_eq!(entries[0].session_id, "fresh");
+        assert_eq!(entries[1].session_id, "expiring_soon");
+        assert_eq!(entries[2].session_id, "expired_recent");
+    }
+
+    #[test]
+    fn sort_project_reverse_puts_z_first() {
+        let now = Utc::now();
+        let mut entries = vec![make_entry("a", now), make_entry("z", now)];
+        sort_entries(&mut entries, SessionsSort::Project, true, now);
+        // project_name = format!("proj-{id}"), so "proj-z" reversed comes first
+        assert_eq!(entries[0].session_id, "z");
+        assert_eq!(entries[1].session_id, "a");
+    }
+
+    #[test]
+    fn sort_size_reverse_puts_smallest_first() {
+        let now = Utc::now();
+        let mut entries = vec![make_entry("big", now), make_entry("small", now)];
+        entries[0].file_size = 10_000;
+        entries[1].file_size = 100;
+        sort_entries(&mut entries, SessionsSort::Size, true, now);
+        assert_eq!(entries[0].session_id, "small");
+        assert_eq!(entries[1].session_id, "big");
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -104,8 +104,7 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
         return;
     }
 
-    let header_cells = sessions_header_cells(app.sessions_sort, app.sort_reverse);
-    let header = Row::new(header_cells.to_vec())
+    let header = Row::new(sessions_header_cells(app.sessions_sort, app.sort_reverse))
         .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
         .bottom_margin(1);
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -104,17 +104,10 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
         return;
     }
 
-    let header = Row::new(vec![
-        "",
-        "ID",
-        "Project",
-        "Mode",
-        "Last",
-        "Cache TTL",
-        "Size",
-    ])
-    .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
-    .bottom_margin(1);
+    let header_cells = sessions_header_cells(app.sessions_sort, app.sort_reverse);
+    let header = Row::new(header_cells.to_vec())
+        .style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
 
     let rows: Vec<Row> = app
         .sessions
@@ -392,6 +385,7 @@ fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) 
             ("↑↓", "navigate"),
             ("←→", "pane"),
             ("s", "sort"),
+            ("S", "reverse"),
             ("r", "refresh"),
             ("Tab", "memory"),
             ("q", "quit"),
@@ -466,6 +460,32 @@ fn ttl_cell_parts(remaining_secs: i64, theme: &Theme, state: State) -> (String, 
 /// already signals the session is cooled off, a BOLD urgency cue would fight it.
 fn ttl_urgent(remaining_secs: i64, state: State) -> bool {
     state == State::Active && (1..TTL_BOLD_SECS).contains(&remaining_secs)
+}
+
+/// Sessions table header labels, with an arrow appended to the active sort
+/// column. `↓` = Desc (newest / largest / longest-TTL first), `↑` = Asc.
+fn sessions_header_cells(sort: sessions::SessionsSort, reverse: bool) -> [String; 7] {
+    let arrow = match sort.effective_direction(reverse) {
+        sessions::SortDirection::Asc => "↑",
+        sessions::SortDirection::Desc => "↓",
+    };
+    let mut cells: [String; 7] = [
+        String::new(),
+        "ID".into(),
+        "Project".into(),
+        "Mode".into(),
+        "Last".into(),
+        "Cache TTL".into(),
+        "Size".into(),
+    ];
+    let idx = match sort {
+        sessions::SessionsSort::Project => 2,
+        sessions::SessionsSort::LastActivity => 4,
+        sessions::SessionsSort::CacheTtl => 5,
+        sessions::SessionsSort::Size => 6,
+    };
+    cells[idx] = format!("{} {}", cells[idx], arrow);
+    cells
 }
 
 fn render_ttl_cell(remaining_secs: i64, theme: &Theme, state: State) -> Cell<'static> {
@@ -587,5 +607,41 @@ mod tests {
     fn ttl_urgent_non_positive_remaining_not_urgent() {
         assert!(!ttl_urgent(0, State::Active));
         assert!(!ttl_urgent(-10, State::Active));
+    }
+
+    #[test]
+    fn header_cells_mark_active_sort_field_with_default_arrow() {
+        let cells = sessions_header_cells(sessions::SessionsSort::LastActivity, false);
+        assert_eq!(cells[4], "Last ↓");
+        assert_eq!(cells[5], "Cache TTL", "inactive field has no arrow");
+        assert_eq!(cells[6], "Size");
+        assert_eq!(cells[2], "Project");
+    }
+
+    #[test]
+    fn header_cells_arrow_flips_when_reversed() {
+        let cells = sessions_header_cells(sessions::SessionsSort::LastActivity, true);
+        assert_eq!(cells[4], "Last ↑");
+    }
+
+    #[test]
+    fn header_cells_cache_ttl_defaults_ascending() {
+        // CacheTtl's natural direction is Asc (expiring-first).
+        let cells = sessions_header_cells(sessions::SessionsSort::CacheTtl, false);
+        assert_eq!(cells[5], "Cache TTL ↑");
+    }
+
+    #[test]
+    fn header_cells_project_sort_marks_column_two() {
+        let cells = sessions_header_cells(sessions::SessionsSort::Project, false);
+        assert_eq!(cells[2], "Project ↑");
+        assert_eq!(cells[4], "Last");
+    }
+
+    #[test]
+    fn header_cells_size_sort_marks_column_six() {
+        let cells = sessions_header_cells(sessions::SessionsSort::Size, false);
+        assert_eq!(cells[6], "Size ↓");
+        assert_eq!(cells[4], "Last");
     }
 }


### PR DESCRIPTION
## Summary
- New `S` key toggles sort direction independently of the `s` field-cycle, resolving [#12](https://github.com/uppinote20/duru/issues/12). Active sort column in the table header now shows `↓` / `↑` indicating the effective direction.
- Fixes a CacheTtl sort UX bug discovered during manual validation: `cache_ttl_remaining_secs` clamps expired sessions to 0, so they clumped at the top of ascending sort despite being the opposite of "needs attention". Expired entries now bucket to the bottom regardless of direction.
- Adds a short comment in the hook scripts documenting that `$PPID` reliably captures the `claude` process itself (verified empirically across 3 live-session scenarios, closes [#16](https://github.com/uppinote20/duru/issues/16)).

## Behavior

Per-field default direction (unchanged from MVP1):

| Field | Default | Reversed |
|---|---|---|
| LastActivity | ↓ newest first | ↑ oldest first (cleanup triage) |
| CacheTtl | ↑ expiring-soonest first | ↓ freshest first |
| Project | ↑ alphabetical | ↓ z→a |
| Size | ↓ largest first | ↑ smallest first (quick-kill triage) |

The `sort_reverse` flag persists across `s` field cycles — one press of `S` flips the direction for every field until toggled again. The header arrow always reflects the effective direction so the current state is visible at a glance.

### CacheTtl expired-bucket

Sessions whose cache has already expired (`remaining_secs == 0`) are now placed after all warm entries, regardless of direction. Within the expired bucket, entries are ordered by `last_activity` desc (most-recently-expired first).

This was discovered during review when the user noticed that `s` → CacheTtl was putting day-old terminated sessions above ones about to expire in the next 10 seconds.

## Changes

- `src/sessions.rs` — `SortDirection` enum, `SessionsSort::default_direction()` / `effective_direction()` methods, `sort_entries` gains a `reverse: bool` argument, CacheTtl arm does warm/expired bucketing.
- `src/app.rs` — `sort_reverse: bool` state, `S` key handler, `refresh_sessions` passes the flag through.
- `src/ui.rs` — `sessions_header_cells(sort, reverse) -> [String; 7]` renders the arrow on the active column, Sessions help bar gains `S reverse`.
- `src/_hook_scripts/session-start.sh` / `user-prompt-submit.sh` — short doc comments referencing #16.
- `README.md` — Sessions mode keys table updated; arrow convention noted.

## Test plan
- [x] `cargo test` — 205 unit + 5 integration, all green. 18 new tests (sort-direction × 4 fields × reverse variants, expired-bucket × 2 directions, header-cell rendering × 5, App `S`-key behavior × 2, plus default-direction table).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo build --release` — clean.
- [x] Manual TUI validation deferred to reviewer — the sort semantics are unit-tested end-to-end, but the arrow rendering + actual key handling is worth a quick `cargo run` to confirm.

Closes #12. Closes #16.