### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "duru"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duru"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Terminal dashboard for Claude Code — explore, manage, and monitor your setup"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.4.0 with the 5 PRs merged since v0.3.1. Release-drafter has the notes prepared; pushing the tag `v0.4.0` after merge will trigger the release workflow (6-target build → upload to existing draft → publish → Homebrew / Scoop auto-update).

## Included since v0.3.1

- #27 — chore: scope libc to Unix targets
- #28 — feat(theme): terminal-colorsaurus dark/light detection
- #29 — feat(hooks): prune old settings.json backups (keep latest 2)
- #30 — fix(ui): mute cache TTL color for stale sessions
- #31 — feat(sessions): sort direction toggle (+ CacheTtl expired bucket + hook PPID docs)

## Why minor (0.3.1 → 0.4.0)

Two new user-facing features (sort direction toggle, improved theme detection) + one new hook behavior (backup pruning). No breaking changes, backward compatible across all fronts. SemVer minor.

## Test plan
- [x] `cargo build` — clean, Cargo.lock updated to 0.4.0
- [x] No code changes beyond the version string
- [ ] Post-merge: tag `v0.4.0`, push; release workflow publishes the prepared draft