### PR TITLE
fix(theme): gate terminal-colorsaurus behind cfg(unix) to fix Windows build

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,6 @@
 use ratatui::style::Color;
+
+#[cfg(unix)]
 use terminal_colorsaurus::{QueryOptions, ThemeMode as DetectedThemeMode, theme_mode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,12 +69,21 @@ impl Theme {
         }
     }
 
+    #[cfg(unix)]
     fn detect() -> Self {
         // OSC 10/11 query; falls back to Dark if no TTY or unsupported terminal.
         match theme_mode(QueryOptions::default()) {
             Ok(DetectedThemeMode::Light) => Self::light(),
             Ok(DetectedThemeMode::Dark) | Err(_) => Self::dark(),
         }
+    }
+
+    #[cfg(not(unix))]
+    fn detect() -> Self {
+        // Windows: `terminal-colorsaurus` is Unix-scoped in Cargo.toml (its OSC
+        // query relies on UNIX terminal semantics). Default to Dark; users can
+        // force the other mode with `--theme light`.
+        Self::dark()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the aarch64-pc-windows-msvc build failure in the v0.4.0 release workflow. `terminal-colorsaurus` is scoped to `cfg(unix)` in `Cargo.toml`, but `src/theme.rs` imported it unconditionally — triggering `error[E0432]: unresolved import 'terminal_colorsaurus'` on Windows targets.

## What broke

- Tag `v0.4.0` was pushed.
- `Release` workflow matrix built 6 targets.
- Unix builds (macOS aarch64/x86_64, Linux GNU/musl) all passed.
- **Windows aarch64 failed to compile** → fail-fast cancelled Windows x86_64 → `release` / `update-homebrew` / `update-scoop` jobs skipped.
- Draft release v0.4.0 still on GitHub as **draft** (was never published), so no consumers are exposed.

## Fix

- `use terminal_colorsaurus::...` now `#[cfg(unix)]`
- `Theme::detect()` splits into two `#[cfg]`-gated impls:
  - `#[cfg(unix)]`: unchanged OSC 10/11 query path
  - `#[cfg(not(unix))]`: returns `Self::dark()` — Windows conhost lacks OSC query semantics; user can force `--theme light` explicitly

## Test plan

- [x] `cargo build` / `cargo test` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` — all clean on macOS
- [ ] CI verifies Linux + macOS (current coverage)
- [ ] Release rerun after merge + tag repush verifies Windows aarch64 + x86_64

## Follow-up (not in this PR)

Consider expanding `.github/workflows/ci.yml` matrix to include `windows-latest` so this class of error surfaces at PR time instead of at release-tag time. Today release is the first Windows build.

## After merge

1. Delete local and remote tag `v0.4.0` (release was never published so no consumers).
2. Re-tag `v0.4.0` at the fixed main.
3. Push tag — triggers release workflow on all 6 targets.
4. Existing draft release body is reused by the workflow's upload step.