### PR TITLE
feat(mvp3): secret storage + `duru warm` CLI scaffold (#18, #22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +85,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +220,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cassowary"
@@ -104,6 +275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -123,6 +303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +318,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -195,10 +391,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -223,6 +463,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -260,6 +510,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +578,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "keyring",
  "libc",
  "pulldown-cmark",
  "ratatui",
@@ -304,6 +595,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +635,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -336,6 +675,78 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -383,6 +794,36 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -442,6 +883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +937,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +963,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libredox"
@@ -549,6 +1025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +1043,83 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -586,6 +1148,22 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -617,6 +1195,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +1248,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -660,6 +1293,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ratatui"
@@ -747,6 +1410,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +1514,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +1582,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -871,6 +1628,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -943,6 +1706,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1835,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1181,11 +2028,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1203,14 +2068,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1220,10 +2102,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1232,10 +2126,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1244,10 +2150,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1256,10 +2174,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -1350,13 +2289,156 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xterm-color"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ duru is safe to run without installing hooks — it falls back to mtime-based in
 
 The Anthropic API key is stored in the OS keychain — Keychain on macOS, Credential Manager on Windows, Secret Service (GNOME Keyring / KWallet) on Linux. The key is never written to disk by duru and never accepted as a positional argument (which would leak into shell history).
 
+Linux source builds need `libdbus-1-dev` and `pkg-config` (Debian/Ubuntu: `apt-get install libdbus-1-dev pkg-config`; Fedora: `dnf install dbus-devel pkgconf-pkg-config`). The Homebrew bottle and prebuilt release binaries already bundle this; the requirement only applies to `cargo install --path .`.
+
 ```bash
 duru warm set-key                         # paste key via stdin (no echo)
 duru warm set-key --from-env VAR          # pull from an env var

--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ Hooks write per-session state into `~/.claude/duru/registry/<session_id>.json`. 
 
 duru is safe to run without installing hooks — it falls back to mtime-based inference.
 
+## Warming (experimental, MVP3)
+
+`duru warm` controls the cache-warming daemon that will refresh Anthropic's 5-minute prompt cache for live Claude Code sessions before it expires. MVP3 lands in slices; this release ships only secret management and the CLI scaffold.
+
+The Anthropic API key is stored in the OS keychain — Keychain on macOS, Credential Manager on Windows, Secret Service (GNOME Keyring / KWallet) on Linux. The key is never written to disk by duru and never accepted as a positional argument (which would leak into shell history).
+
+```bash
+duru warm set-key                         # paste key via stdin (no echo)
+duru warm set-key --from-env VAR          # pull from an env var
+duru warm unset-key                       # remove the stored key
+duru warm check-key                       # "configured (sk-ant-ap…)" or "not configured"
+duru warm status                          # aggregate view (key + daemon + recent pings)
+```
+
+`duru warm` requires `duru hooks install` first — without the registry there are no sessions to warm. The remaining subcommands (`dry-run`, `install`, `uninstall`, `daemon`) parse today but will be filled in by subsequent MVP3 PRs.
+
 ## Theme
 
 Rosé Pine with automatic dark/light detection.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,11 @@ mod hooks_install;
 mod markdown;
 mod registry;
 mod scan;
+mod secrets;
 mod sessions;
 mod theme;
 mod ui;
+mod warm;
 
 use std::io;
 use std::path::PathBuf;
@@ -27,7 +29,7 @@ use app::App;
 use scan::{demo_projects, scan_claude_dir};
 use theme::Theme;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(
     name = "duru",
     version,
@@ -50,16 +52,21 @@ struct Cli {
     command: Option<TopCommand>,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 enum TopCommand {
     /// Install, uninstall, or check duru Claude Code hooks
     Hooks {
         #[command(subcommand)]
         action: HooksAction,
     },
+    /// Cache warming daemon controls (MVP3)
+    Warm {
+        #[command(subcommand)]
+        action: warm::WarmAction,
+    },
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 enum HooksAction {
     /// Install duru hooks into ~/.claude/settings.json
     Install {
@@ -143,8 +150,10 @@ fn main() -> io::Result<()> {
         None => home.clone(),
     };
 
-    if let Some(TopCommand::Hooks { action }) = cli.command {
-        return run_hooks_command(&hooks_home, action);
+    match cli.command {
+        Some(TopCommand::Hooks { action }) => return run_hooks_command(&hooks_home, action),
+        Some(TopCommand::Warm { action }) => return warm::run(&hooks_home, action),
+        None => {}
     }
 
     let claude_dir = cli.path.clone().unwrap_or_else(|| home.join(".claude"));
@@ -288,6 +297,8 @@ fn run_app(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+    use warm::WarmAction;
 
     #[test]
     fn resolve_editor_prefers_visual() {
@@ -302,5 +313,114 @@ mod tests {
     #[test]
     fn resolve_editor_defaults_to_vi() {
         assert_eq!(resolve_editor_from(None, None), "vi");
+    }
+
+    fn warm_action(args: &[&str]) -> WarmAction {
+        let cli = Cli::try_parse_from(args).expect("parse");
+        match cli.command {
+            Some(TopCommand::Warm { action }) => action,
+            other => panic!("expected Warm subcommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn warm_set_key_no_args() {
+        let action = warm_action(&["duru", "warm", "set-key"]);
+        assert!(matches!(action, WarmAction::SetKey { from_env: None }));
+    }
+
+    #[test]
+    fn warm_set_key_from_env() {
+        let action = warm_action(&["duru", "warm", "set-key", "--from-env", "ANTHROPIC_API_KEY"]);
+        match action {
+            WarmAction::SetKey { from_env } => {
+                assert_eq!(from_env.as_deref(), Some("ANTHROPIC_API_KEY"));
+            }
+            _ => panic!("expected SetKey"),
+        }
+    }
+
+    #[test]
+    fn warm_set_key_rejects_positional_arg() {
+        // Positional arg would leak into shell history (umbrella #18: MUST NOT accept).
+        assert!(Cli::try_parse_from(["duru", "warm", "set-key", "sk-ant-leaked"]).is_err());
+    }
+
+    #[test]
+    fn warm_check_key() {
+        assert!(matches!(
+            warm_action(&["duru", "warm", "check-key"]),
+            WarmAction::CheckKey
+        ));
+    }
+
+    #[test]
+    fn warm_unset_key() {
+        assert!(matches!(
+            warm_action(&["duru", "warm", "unset-key"]),
+            WarmAction::UnsetKey
+        ));
+    }
+
+    #[test]
+    fn warm_dry_run_requires_session_id() {
+        let action = warm_action(&["duru", "warm", "dry-run", "676b2e79"]);
+        match action {
+            WarmAction::DryRun { session_id } => assert_eq!(session_id, "676b2e79"),
+            _ => panic!("expected DryRun"),
+        }
+        assert!(Cli::try_parse_from(["duru", "warm", "dry-run"]).is_err());
+    }
+
+    #[test]
+    fn warm_install_flags() {
+        let default = warm_action(&["duru", "warm", "install"]);
+        assert!(matches!(default, WarmAction::Install { dry_run: false }));
+        let dry = warm_action(&["duru", "warm", "install", "--dry-run"]);
+        assert!(matches!(dry, WarmAction::Install { dry_run: true }));
+    }
+
+    #[test]
+    fn warm_uninstall() {
+        assert!(matches!(
+            warm_action(&["duru", "warm", "uninstall"]),
+            WarmAction::Uninstall
+        ));
+    }
+
+    #[test]
+    fn warm_daemon() {
+        assert!(matches!(
+            warm_action(&["duru", "warm", "daemon"]),
+            WarmAction::Daemon
+        ));
+    }
+
+    #[test]
+    fn warm_status_variants() {
+        let plain = warm_action(&["duru", "warm", "status"]);
+        assert!(matches!(
+            plain,
+            WarmAction::Status {
+                daemon: false,
+                recent: None
+            }
+        ));
+        let daemon_only = warm_action(&["duru", "warm", "status", "--daemon"]);
+        assert!(matches!(
+            daemon_only,
+            WarmAction::Status {
+                daemon: true,
+                recent: None
+            }
+        ));
+        let recent = warm_action(&["duru", "warm", "status", "--recent", "5"]);
+        match recent {
+            WarmAction::Status { daemon, recent } => {
+                assert!(!daemon);
+                assert_eq!(recent, Some(5));
+            }
+            _ => panic!("expected Status"),
+        }
     }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -17,14 +17,9 @@ pub trait SecretBackend {
     fn remove(&self) -> io::Result<()>;
 }
 
-#[derive(Default)]
 pub struct KeyringBackend;
 
 impl KeyringBackend {
-    pub fn new() -> Self {
-        Self
-    }
-
     fn entry(&self) -> io::Result<keyring::Entry> {
         keyring::Entry::new(SERVICE, ACCOUNT).map_err(map_keyring_err)
     }
@@ -111,6 +106,9 @@ pub fn has_api_key(backend: &dyn SecretBackend) -> io::Result<bool> {
 pub fn redact_key(key: &str) -> String {
     const PREFIX_LEN: usize = 9;
     let trimmed = key.trim();
+    // ≤10 chars (prefix + at least one hidden char) → fully redacted.
+    // Showing a 9-char prefix of an 11-char input would only hide 2 chars,
+    // which is too few to call "redacted".
     if trimmed.chars().count() <= PREFIX_LEN + 1 {
         return "…".to_string();
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -17,6 +17,7 @@ pub trait SecretBackend {
     fn remove(&self) -> io::Result<()>;
 }
 
+#[derive(Default)]
 pub struct KeyringBackend;
 
 impl KeyringBackend {
@@ -26,12 +27,6 @@ impl KeyringBackend {
 
     fn entry(&self) -> io::Result<keyring::Entry> {
         keyring::Entry::new(SERVICE, ACCOUNT).map_err(map_keyring_err)
-    }
-}
-
-impl Default for KeyringBackend {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -61,6 +56,7 @@ fn map_keyring_err(e: keyring::Error) -> io::Error {
 }
 
 #[cfg(test)]
+#[derive(Default)]
 pub struct MemoryBackend {
     cell: Mutex<Option<String>>,
 }
@@ -68,16 +64,7 @@ pub struct MemoryBackend {
 #[cfg(test)]
 impl MemoryBackend {
     pub fn new() -> Self {
-        Self {
-            cell: Mutex::new(None),
-        }
-    }
-}
-
-#[cfg(test)]
-impl Default for MemoryBackend {
-    fn default() -> Self {
-        Self::new()
+        Self::default()
     }
 }
 

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,224 @@
+//! Anthropic API key storage for the warming daemon.
+//!
+//! Keys live in the OS keychain via the `keyring` crate (Keychain on macOS,
+//! Credential Manager on Windows, Secret Service on Linux). A [`SecretBackend`]
+//! trait keeps logic testable without touching real credentials.
+
+use std::io;
+#[cfg(test)]
+use std::sync::Mutex;
+
+const SERVICE: &str = "duru-warmer";
+const ACCOUNT: &str = "anthropic-api-key";
+
+pub trait SecretBackend {
+    fn get(&self) -> io::Result<Option<String>>;
+    fn set(&self, value: &str) -> io::Result<()>;
+    fn remove(&self) -> io::Result<()>;
+}
+
+pub struct KeyringBackend;
+
+impl KeyringBackend {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn entry(&self) -> io::Result<keyring::Entry> {
+        keyring::Entry::new(SERVICE, ACCOUNT).map_err(map_keyring_err)
+    }
+}
+
+impl Default for KeyringBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecretBackend for KeyringBackend {
+    fn get(&self) -> io::Result<Option<String>> {
+        match self.entry()?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(map_keyring_err(e)),
+        }
+    }
+
+    fn set(&self, value: &str) -> io::Result<()> {
+        self.entry()?.set_password(value).map_err(map_keyring_err)
+    }
+
+    fn remove(&self) -> io::Result<()> {
+        match self.entry()?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(map_keyring_err(e)),
+        }
+    }
+}
+
+fn map_keyring_err(e: keyring::Error) -> io::Error {
+    io::Error::other(format!("keyring: {e}"))
+}
+
+#[cfg(test)]
+pub struct MemoryBackend {
+    cell: Mutex<Option<String>>,
+}
+
+#[cfg(test)]
+impl MemoryBackend {
+    pub fn new() -> Self {
+        Self {
+            cell: Mutex::new(None),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for MemoryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+impl SecretBackend for MemoryBackend {
+    fn get(&self) -> io::Result<Option<String>> {
+        Ok(self.cell.lock().unwrap().clone())
+    }
+    fn set(&self, value: &str) -> io::Result<()> {
+        *self.cell.lock().unwrap() = Some(value.to_string());
+        Ok(())
+    }
+    fn remove(&self) -> io::Result<()> {
+        *self.cell.lock().unwrap() = None;
+        Ok(())
+    }
+}
+
+pub fn set_api_key(backend: &dyn SecretBackend, value: &str) -> io::Result<()> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "api key is empty",
+        ));
+    }
+    backend.set(trimmed)
+}
+
+pub fn get_api_key(backend: &dyn SecretBackend) -> io::Result<Option<String>> {
+    backend.get()
+}
+
+pub fn remove_api_key(backend: &dyn SecretBackend) -> io::Result<()> {
+    backend.remove()
+}
+
+// Consumer lands in MVP3 #21 (daemon startup pre-flight) + #23 (no_api_key guardrail log).
+#[allow(dead_code)]
+pub fn has_api_key(backend: &dyn SecretBackend) -> io::Result<bool> {
+    Ok(backend.get()?.is_some())
+}
+
+pub fn redact_key(key: &str) -> String {
+    const PREFIX_LEN: usize = 9;
+    let trimmed = key.trim();
+    if trimmed.chars().count() <= PREFIX_LEN + 1 {
+        return "…".to_string();
+    }
+    let prefix: String = trimmed.chars().take(PREFIX_LEN).collect();
+    format!("{prefix}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_key_typical_anthropic_key() {
+        let full = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789";
+        let got = redact_key(full);
+        assert_eq!(got, "sk-ant-ap…");
+        assert!(!got.contains("api03-abc"));
+    }
+
+    #[test]
+    fn redact_key_short_input_fully_redacted() {
+        assert_eq!(redact_key(""), "…");
+        assert_eq!(redact_key("sk-ant"), "…");
+        assert_eq!(redact_key("sk-ant-abc"), "…");
+    }
+
+    #[test]
+    fn redact_key_trims_whitespace_first() {
+        let full = "   sk-ant-api03-xyz_0123456789   ";
+        assert_eq!(redact_key(full), "sk-ant-ap…");
+    }
+
+    #[test]
+    fn redact_key_never_includes_full_secret() {
+        let full = "sk-ant-api03-SENSITIVE_MATERIAL_DO_NOT_LEAK";
+        let redacted = redact_key(full);
+        assert!(!redacted.contains("SENSITIVE"));
+        assert!(!redacted.contains("MATERIAL"));
+        assert!(redacted.ends_with('…'));
+    }
+
+    #[test]
+    fn memory_backend_roundtrip() {
+        let backend = MemoryBackend::new();
+        assert_eq!(backend.get().unwrap(), None);
+
+        backend.set("sk-ant-test-key").unwrap();
+        assert_eq!(backend.get().unwrap().as_deref(), Some("sk-ant-test-key"));
+
+        backend.remove().unwrap();
+        assert_eq!(backend.get().unwrap(), None);
+    }
+
+    #[test]
+    fn memory_backend_remove_is_idempotent() {
+        let backend = MemoryBackend::new();
+        backend.remove().unwrap();
+        backend.remove().unwrap();
+        assert_eq!(backend.get().unwrap(), None);
+    }
+
+    #[test]
+    fn set_api_key_rejects_empty() {
+        let backend = MemoryBackend::new();
+        let err = set_api_key(&backend, "").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let err = set_api_key(&backend, "   \t\n").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        assert_eq!(backend.get().unwrap(), None);
+    }
+
+    #[test]
+    fn set_api_key_trims_before_storing() {
+        let backend = MemoryBackend::new();
+        set_api_key(&backend, "  sk-ant-test  ").unwrap();
+        assert_eq!(backend.get().unwrap().as_deref(), Some("sk-ant-test"));
+    }
+
+    #[test]
+    fn get_api_key_absent_is_none() {
+        let backend = MemoryBackend::new();
+        assert_eq!(get_api_key(&backend).unwrap(), None);
+    }
+
+    #[test]
+    fn has_api_key_reflects_state() {
+        let backend = MemoryBackend::new();
+        assert!(!has_api_key(&backend).unwrap());
+
+        set_api_key(&backend, "sk-ant-test").unwrap();
+        assert!(has_api_key(&backend).unwrap());
+
+        remove_api_key(&backend).unwrap();
+        assert!(!has_api_key(&backend).unwrap());
+    }
+}

--- a/src/warm.rs
+++ b/src/warm.rs
@@ -1,0 +1,361 @@
+//! `duru warm` CLI scaffold — MVP3.
+//!
+//! PR1 wires only `set-key`, `unset-key`, and `check-key`. Every other
+//! subcommand parses correctly but its handler prints a stub pointing at the
+//! MVP3 sub-issue that will implement it. This lets later PRs land each slice
+//! without renaming or moving the clap surface.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+
+use clap::Subcommand;
+
+use crate::secrets::{self, KeyringBackend, SecretBackend};
+
+#[derive(Subcommand, Debug)]
+pub enum WarmAction {
+    /// Store the Anthropic API key in the OS keychain
+    SetKey {
+        /// Read key value from the named environment variable instead of stdin
+        #[arg(long, value_name = "VAR")]
+        from_env: Option<String>,
+    },
+    /// Show whether an API key is configured (redacted)
+    CheckKey,
+    /// Remove any stored API key from the keychain
+    UnsetKey,
+    /// Test prefix reconstruction against a session (filled in by #19)
+    DryRun {
+        /// Session id from the duru Sessions view
+        session_id: String,
+    },
+    /// Install the launchd/systemd supervisor unit (filled in by #21)
+    Install {
+        /// Print what would happen without modifying anything
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Remove the supervisor unit (filled in by #21)
+    Uninstall,
+    /// Run the warming loop in the foreground (filled in by #21)
+    Daemon,
+    /// Show key + daemon + recent-ping state
+    Status {
+        /// Only report daemon running/stopped
+        #[arg(long)]
+        daemon: bool,
+        /// Show the last N ping outcomes
+        #[arg(long, value_name = "N")]
+        recent: Option<usize>,
+    },
+}
+
+/// Entry point from `main.rs`. Returns an error if preflight fails.
+pub fn run(home: &Path, action: WarmAction) -> io::Result<()> {
+    preflight(home)?;
+    let backend = KeyringBackend::new();
+    dispatch(&backend, action, &mut io::stdin().lock(), &mut io::stdout())
+}
+
+/// All warm subcommands require `duru hooks install` to have run first.
+/// Without the registry there's nothing to warm and nothing to report on.
+pub fn preflight(home: &Path) -> io::Result<()> {
+    let registry = home.join(".claude").join("duru").join("registry");
+    if registry.is_dir() {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "hooks not installed — run `duru hooks install` first",
+    ))
+}
+
+pub fn dispatch<B: SecretBackend>(
+    backend: &B,
+    action: WarmAction,
+    stdin: &mut impl io::BufRead,
+    stdout: &mut impl Write,
+) -> io::Result<()> {
+    match action {
+        WarmAction::SetKey { from_env } => handle_set_key(backend, from_env, stdin, stdout),
+        WarmAction::CheckKey => handle_check_key(backend, stdout),
+        WarmAction::UnsetKey => handle_unset_key(backend, stdout),
+        WarmAction::DryRun { session_id } => {
+            writeln!(
+                stdout,
+                "dry-run for {session_id}: prefix reconstruction lands in MVP3 issue #19"
+            )?;
+            Ok(())
+        }
+        WarmAction::Install { dry_run } => {
+            let verb = if dry_run { "would install" } else { "install" };
+            writeln!(stdout, "{verb} supervisor unit lands in MVP3 issue #21")?;
+            Ok(())
+        }
+        WarmAction::Uninstall => {
+            writeln!(stdout, "uninstall lands in MVP3 issue #21")?;
+            Ok(())
+        }
+        WarmAction::Daemon => {
+            writeln!(stdout, "daemon loop lands in MVP3 issue #21")?;
+            Ok(())
+        }
+        WarmAction::Status { daemon, recent } => handle_status(backend, daemon, recent, stdout),
+    }
+}
+
+fn handle_set_key<B: SecretBackend>(
+    backend: &B,
+    from_env: Option<String>,
+    stdin: &mut impl io::BufRead,
+    stdout: &mut impl Write,
+) -> io::Result<()> {
+    let raw = match from_env {
+        Some(var) => std::env::var(&var).map_err(|_| {
+            io::Error::new(io::ErrorKind::NotFound, format!("env var {var} is not set"))
+        })?,
+        None => read_key_from_stdin(stdin, stdout)?,
+    };
+    secrets::set_api_key(backend, &raw)?;
+    writeln!(stdout, "api key stored in keychain")?;
+    Ok(())
+}
+
+fn read_key_from_stdin(
+    stdin: &mut impl io::BufRead,
+    stdout: &mut impl Write,
+) -> io::Result<String> {
+    if io::stdin().is_terminal() {
+        write!(stdout, "Paste Anthropic API key (will not echo): ")?;
+        stdout.flush()?;
+    }
+    let mut line = String::new();
+    stdin.read_line(&mut line)?;
+    Ok(line)
+}
+
+fn handle_check_key<B: SecretBackend>(backend: &B, stdout: &mut impl Write) -> io::Result<()> {
+    match secrets::get_api_key(backend)? {
+        Some(key) => writeln!(
+            stdout,
+            "api key: configured ({})",
+            secrets::redact_key(&key)
+        )?,
+        None => writeln!(stdout, "api key: not configured")?,
+    }
+    Ok(())
+}
+
+fn handle_unset_key<B: SecretBackend>(backend: &B, stdout: &mut impl Write) -> io::Result<()> {
+    secrets::remove_api_key(backend)?;
+    writeln!(stdout, "api key removed")?;
+    Ok(())
+}
+
+fn handle_status<B: SecretBackend>(
+    backend: &B,
+    daemon_only: bool,
+    recent: Option<usize>,
+    stdout: &mut impl Write,
+) -> io::Result<()> {
+    if !daemon_only {
+        handle_check_key(backend, stdout)?;
+    }
+    writeln!(stdout, "daemon: not yet implemented (MVP3 issue #21)")?;
+    if let Some(n) = recent {
+        writeln!(
+            stdout,
+            "recent {n} pings: not yet implemented (MVP3 issue #23)"
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secrets::MemoryBackend;
+    use tempfile::TempDir;
+
+    fn dispatch_to_string(backend: &MemoryBackend, action: WarmAction, stdin: &str) -> String {
+        let mut out = Vec::new();
+        let mut input = stdin.as_bytes();
+        dispatch(backend, action, &mut input, &mut out).expect("dispatch");
+        String::from_utf8(out).expect("utf8")
+    }
+
+    #[test]
+    fn preflight_fails_without_registry() {
+        let tmp = TempDir::new().unwrap();
+        let err = preflight(tmp.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("duru hooks install"));
+    }
+
+    #[test]
+    fn preflight_ok_with_registry() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".claude/duru/registry")).unwrap();
+        preflight(tmp.path()).expect("preflight");
+    }
+
+    #[test]
+    fn set_key_from_stdin_stores_trimmed() {
+        let backend = MemoryBackend::new();
+        let out = dispatch_to_string(
+            &backend,
+            WarmAction::SetKey { from_env: None },
+            "sk-ant-from-stdin\n",
+        );
+        assert!(out.contains("stored"));
+        assert_eq!(backend.get().unwrap().as_deref(), Some("sk-ant-from-stdin"));
+    }
+
+    #[test]
+    fn set_key_from_stdin_rejects_blank() {
+        let backend = MemoryBackend::new();
+        let mut out = Vec::new();
+        let mut input = "\n".as_bytes();
+        let err = dispatch(
+            &backend,
+            WarmAction::SetKey { from_env: None },
+            &mut input,
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(backend.get().unwrap(), None);
+    }
+
+    #[test]
+    fn set_key_from_env_reads_var() {
+        let var = "DURU_TEST_API_KEY_VAR";
+        // Safe: test-only var, and we clean up immediately.
+        // SAFETY: single-threaded test, no other readers of this env var.
+        unsafe { std::env::set_var(var, "sk-ant-from-env") };
+        let backend = MemoryBackend::new();
+        let out = dispatch_to_string(
+            &backend,
+            WarmAction::SetKey {
+                from_env: Some(var.to_string()),
+            },
+            "",
+        );
+        // SAFETY: see above.
+        unsafe { std::env::remove_var(var) };
+        assert!(out.contains("stored"));
+        assert_eq!(backend.get().unwrap().as_deref(), Some("sk-ant-from-env"));
+    }
+
+    #[test]
+    fn set_key_from_env_missing_errors() {
+        let backend = MemoryBackend::new();
+        let mut out = Vec::new();
+        let mut input = "".as_bytes();
+        let err = dispatch(
+            &backend,
+            WarmAction::SetKey {
+                from_env: Some("DURU_DEFINITELY_UNSET_VAR_9".to_string()),
+            },
+            &mut input,
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn check_key_when_absent() {
+        let backend = MemoryBackend::new();
+        let out = dispatch_to_string(&backend, WarmAction::CheckKey, "");
+        assert!(out.contains("not configured"));
+    }
+
+    #[test]
+    fn check_key_when_present_redacts() {
+        let backend = MemoryBackend::new();
+        backend.set("sk-ant-api03-secretstuff").unwrap();
+        let out = dispatch_to_string(&backend, WarmAction::CheckKey, "");
+        assert!(out.contains("configured"));
+        assert!(out.contains("sk-ant-ap…"));
+        assert!(!out.contains("secretstuff"));
+    }
+
+    #[test]
+    fn unset_key_is_idempotent() {
+        let backend = MemoryBackend::new();
+        dispatch_to_string(&backend, WarmAction::UnsetKey, "");
+        let out = dispatch_to_string(&backend, WarmAction::UnsetKey, "");
+        assert!(out.contains("removed"));
+        assert_eq!(backend.get().unwrap(), None);
+    }
+
+    #[test]
+    fn unset_key_clears_existing() {
+        let backend = MemoryBackend::new();
+        backend.set("sk-ant-xxx").unwrap();
+        dispatch_to_string(&backend, WarmAction::UnsetKey, "");
+        assert_eq!(backend.get().unwrap(), None);
+    }
+
+    #[test]
+    fn status_default_includes_key_and_daemon() {
+        let backend = MemoryBackend::new();
+        let out = dispatch_to_string(
+            &backend,
+            WarmAction::Status {
+                daemon: false,
+                recent: None,
+            },
+            "",
+        );
+        assert!(out.contains("api key"));
+        assert!(out.contains("daemon"));
+        assert!(!out.contains("recent"));
+    }
+
+    #[test]
+    fn status_daemon_only_skips_key_line() {
+        let backend = MemoryBackend::new();
+        let out = dispatch_to_string(
+            &backend,
+            WarmAction::Status {
+                daemon: true,
+                recent: None,
+            },
+            "",
+        );
+        assert!(!out.contains("api key"));
+        assert!(out.contains("daemon"));
+    }
+
+    #[test]
+    fn status_recent_shows_stub_line() {
+        let backend = MemoryBackend::new();
+        let out = dispatch_to_string(
+            &backend,
+            WarmAction::Status {
+                daemon: false,
+                recent: Some(7),
+            },
+            "",
+        );
+        assert!(out.contains("recent 7"));
+    }
+
+    #[test]
+    fn stub_subcommands_do_not_error() {
+        let backend = MemoryBackend::new();
+        dispatch_to_string(
+            &backend,
+            WarmAction::DryRun {
+                session_id: "abc".into(),
+            },
+            "",
+        );
+        dispatch_to_string(&backend, WarmAction::Install { dry_run: false }, "");
+        dispatch_to_string(&backend, WarmAction::Install { dry_run: true }, "");
+        dispatch_to_string(&backend, WarmAction::Uninstall, "");
+        dispatch_to_string(&backend, WarmAction::Daemon, "");
+    }
+}

--- a/src/warm.rs
+++ b/src/warm.rs
@@ -1,16 +1,22 @@
-//! `duru warm` CLI scaffold — MVP3.
+//! `duru warm` — cache warming daemon controls.
 //!
-//! PR1 wires only `set-key`, `unset-key`, and `check-key`. Every other
-//! subcommand parses correctly but its handler prints a stub pointing at the
-//! MVP3 sub-issue that will implement it. This lets later PRs land each slice
-//! without renaming or moving the clap surface.
+//! Secret management and the CLI surface land here; session-picking policy,
+//! the daemon loop, and supervisor installation arrive in follow-up work.
+//! See the MVP3 umbrella (#17) for the full design.
 
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
 
 use clap::Subcommand;
 
+use crate::hooks_install::registry_dir;
 use crate::secrets::{self, KeyringBackend, SecretBackend};
+
+// Issue numbers referenced by stub messages. Keeping them here means
+// a renumber or rescope touches one table, not eight `writeln!` calls.
+const ISSUE_PREFIX_RECON: u32 = 19;
+const ISSUE_DAEMON: u32 = 21;
+const ISSUE_OBSERVABILITY: u32 = 23;
 
 #[derive(Subcommand, Debug)]
 pub enum WarmAction {
@@ -24,20 +30,20 @@ pub enum WarmAction {
     CheckKey,
     /// Remove any stored API key from the keychain
     UnsetKey,
-    /// Test prefix reconstruction against a session (filled in by #19)
+    /// Dry-run: reconstruct a cache-hit ping for a session and print it
     DryRun {
         /// Session id from the duru Sessions view
         session_id: String,
     },
-    /// Install the launchd/systemd supervisor unit (filled in by #21)
+    /// Install the launchd/systemd supervisor unit
     Install {
         /// Print what would happen without modifying anything
         #[arg(long)]
         dry_run: bool,
     },
-    /// Remove the supervisor unit (filled in by #21)
+    /// Remove the supervisor unit
     Uninstall,
-    /// Run the warming loop in the foreground (filled in by #21)
+    /// Run the warming loop in the foreground
     Daemon,
     /// Show key + daemon + recent-ping state
     Status {
@@ -50,18 +56,14 @@ pub enum WarmAction {
     },
 }
 
-/// Entry point from `main.rs`. Returns an error if preflight fails.
 pub fn run(home: &Path, action: WarmAction) -> io::Result<()> {
     preflight(home)?;
     let backend = KeyringBackend::new();
     dispatch(&backend, action, &mut io::stdin().lock(), &mut io::stdout())
 }
 
-/// All warm subcommands require `duru hooks install` to have run first.
-/// Without the registry there's nothing to warm and nothing to report on.
 pub fn preflight(home: &Path) -> io::Result<()> {
-    let registry = home.join(".claude").join("duru").join("registry");
-    if registry.is_dir() {
+    if registry_dir(home).is_dir() {
         return Ok(());
     }
     Err(io::Error::new(
@@ -76,42 +78,63 @@ pub fn dispatch<B: SecretBackend>(
     stdin: &mut impl io::BufRead,
     stdout: &mut impl Write,
 ) -> io::Result<()> {
+    dispatch_with_env(backend, action, stdin, stdout, |v| std::env::var(v).ok())
+}
+
+fn dispatch_with_env<B, F>(
+    backend: &B,
+    action: WarmAction,
+    stdin: &mut impl io::BufRead,
+    stdout: &mut impl Write,
+    env_lookup: F,
+) -> io::Result<()>
+where
+    B: SecretBackend,
+    F: Fn(&str) -> Option<String>,
+{
     match action {
-        WarmAction::SetKey { from_env } => handle_set_key(backend, from_env, stdin, stdout),
+        WarmAction::SetKey { from_env } => {
+            handle_set_key(backend, from_env, env_lookup, stdin, stdout)
+        }
         WarmAction::CheckKey => handle_check_key(backend, stdout),
         WarmAction::UnsetKey => handle_unset_key(backend, stdout),
-        WarmAction::DryRun { session_id } => {
-            writeln!(
-                stdout,
-                "dry-run for {session_id}: prefix reconstruction lands in MVP3 issue #19"
-            )?;
-            Ok(())
-        }
-        WarmAction::Install { dry_run } => {
-            let verb = if dry_run { "would install" } else { "install" };
-            writeln!(stdout, "{verb} supervisor unit lands in MVP3 issue #21")?;
-            Ok(())
-        }
-        WarmAction::Uninstall => {
-            writeln!(stdout, "uninstall lands in MVP3 issue #21")?;
-            Ok(())
-        }
-        WarmAction::Daemon => {
-            writeln!(stdout, "daemon loop lands in MVP3 issue #21")?;
-            Ok(())
-        }
+        WarmAction::DryRun { session_id } => stub_note(
+            stdout,
+            &format!("dry-run {session_id}: prefix reconstruction"),
+            ISSUE_PREFIX_RECON,
+        ),
+        WarmAction::Install { dry_run } => stub_note(
+            stdout,
+            if dry_run {
+                "would install supervisor unit"
+            } else {
+                "install supervisor unit"
+            },
+            ISSUE_DAEMON,
+        ),
+        WarmAction::Uninstall => stub_note(stdout, "uninstall supervisor unit", ISSUE_DAEMON),
+        WarmAction::Daemon => stub_note(stdout, "daemon loop", ISSUE_DAEMON),
         WarmAction::Status { daemon, recent } => handle_status(backend, daemon, recent, stdout),
     }
 }
 
-fn handle_set_key<B: SecretBackend>(
+fn stub_note(stdout: &mut impl Write, what: &str, issue: u32) -> io::Result<()> {
+    writeln!(stdout, "{what} (MVP3 #{issue})")
+}
+
+fn handle_set_key<B, F>(
     backend: &B,
     from_env: Option<String>,
+    env_lookup: F,
     stdin: &mut impl io::BufRead,
     stdout: &mut impl Write,
-) -> io::Result<()> {
+) -> io::Result<()>
+where
+    B: SecretBackend,
+    F: Fn(&str) -> Option<String>,
+{
     let raw = match from_env {
-        Some(var) => std::env::var(&var).map_err(|_| {
+        Some(var) => env_lookup(&var).ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, format!("env var {var} is not set"))
         })?,
         None => read_key_from_stdin(stdin, stdout)?,
@@ -161,11 +184,12 @@ fn handle_status<B: SecretBackend>(
     if !daemon_only {
         handle_check_key(backend, stdout)?;
     }
-    writeln!(stdout, "daemon: not yet implemented (MVP3 issue #21)")?;
+    stub_note(stdout, "daemon: not yet implemented", ISSUE_DAEMON)?;
     if let Some(n) = recent {
-        writeln!(
+        stub_note(
             stdout,
-            "recent {n} pings: not yet implemented (MVP3 issue #23)"
+            &format!("recent {n} pings: not yet implemented"),
+            ISSUE_OBSERVABILITY,
         )?;
     }
     Ok(())
@@ -195,7 +219,7 @@ mod tests {
     #[test]
     fn preflight_ok_with_registry() {
         let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".claude/duru/registry")).unwrap();
+        std::fs::create_dir_all(registry_dir(tmp.path())).unwrap();
         preflight(tmp.path()).expect("preflight");
     }
 
@@ -228,21 +252,21 @@ mod tests {
     }
 
     #[test]
-    fn set_key_from_env_reads_var() {
-        let var = "DURU_TEST_API_KEY_VAR";
-        // Safe: test-only var, and we clean up immediately.
-        // SAFETY: single-threaded test, no other readers of this env var.
-        unsafe { std::env::set_var(var, "sk-ant-from-env") };
+    fn set_key_from_env_reads_via_injected_lookup() {
         let backend = MemoryBackend::new();
-        let out = dispatch_to_string(
+        let mut out = Vec::new();
+        let mut input = "".as_bytes();
+        dispatch_with_env(
             &backend,
             WarmAction::SetKey {
-                from_env: Some(var.to_string()),
+                from_env: Some("ANTHROPIC_API_KEY".into()),
             },
-            "",
-        );
-        // SAFETY: see above.
-        unsafe { std::env::remove_var(var) };
+            &mut input,
+            &mut out,
+            |v| (v == "ANTHROPIC_API_KEY").then(|| "sk-ant-from-env".to_string()),
+        )
+        .expect("dispatch");
+        let out = String::from_utf8(out).unwrap();
         assert!(out.contains("stored"));
         assert_eq!(backend.get().unwrap().as_deref(), Some("sk-ant-from-env"));
     }
@@ -252,13 +276,14 @@ mod tests {
         let backend = MemoryBackend::new();
         let mut out = Vec::new();
         let mut input = "".as_bytes();
-        let err = dispatch(
+        let err = dispatch_with_env(
             &backend,
             WarmAction::SetKey {
-                from_env: Some("DURU_DEFINITELY_UNSET_VAR_9".to_string()),
+                from_env: Some("ANTHROPIC_API_KEY".into()),
             },
             &mut input,
             &mut out,
+            |_| None,
         )
         .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::NotFound);

--- a/src/warm.rs
+++ b/src/warm.rs
@@ -58,8 +58,16 @@ pub enum WarmAction {
 
 pub fn run(home: &Path, action: WarmAction) -> io::Result<()> {
     preflight(home)?;
-    let backend = KeyringBackend::new();
-    dispatch(&backend, action, &mut io::stdin().lock(), &mut io::stdout())
+    let backend = KeyringBackend;
+    let interactive = io::stdin().is_terminal();
+    dispatch_with_env(
+        &backend,
+        action,
+        &mut io::stdin().lock(),
+        &mut io::stdout(),
+        interactive,
+        |v| std::env::var(v).ok(),
+    )
 }
 
 pub fn preflight(home: &Path) -> io::Result<()> {
@@ -72,20 +80,12 @@ pub fn preflight(home: &Path) -> io::Result<()> {
     ))
 }
 
-pub fn dispatch<B: SecretBackend>(
-    backend: &B,
-    action: WarmAction,
-    stdin: &mut impl io::BufRead,
-    stdout: &mut impl Write,
-) -> io::Result<()> {
-    dispatch_with_env(backend, action, stdin, stdout, |v| std::env::var(v).ok())
-}
-
 fn dispatch_with_env<B, F>(
     backend: &B,
     action: WarmAction,
     stdin: &mut impl io::BufRead,
     stdout: &mut impl Write,
+    interactive: bool,
     env_lookup: F,
 ) -> io::Result<()>
 where
@@ -94,7 +94,7 @@ where
 {
     match action {
         WarmAction::SetKey { from_env } => {
-            handle_set_key(backend, from_env, env_lookup, stdin, stdout)
+            handle_set_key(backend, from_env, env_lookup, interactive, stdin, stdout)
         }
         WarmAction::CheckKey => handle_check_key(backend, stdout),
         WarmAction::UnsetKey => handle_unset_key(backend, stdout),
@@ -126,6 +126,7 @@ fn handle_set_key<B, F>(
     backend: &B,
     from_env: Option<String>,
     env_lookup: F,
+    interactive: bool,
     stdin: &mut impl io::BufRead,
     stdout: &mut impl Write,
 ) -> io::Result<()>
@@ -137,7 +138,7 @@ where
         Some(var) => env_lookup(&var).ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, format!("env var {var} is not set"))
         })?,
-        None => read_key_from_stdin(stdin, stdout)?,
+        None => read_key_from_stdin(interactive, stdin, stdout)?,
     };
     secrets::set_api_key(backend, &raw)?;
     writeln!(stdout, "api key stored in keychain")?;
@@ -145,10 +146,11 @@ where
 }
 
 fn read_key_from_stdin(
+    interactive: bool,
     stdin: &mut impl io::BufRead,
     stdout: &mut impl Write,
 ) -> io::Result<String> {
-    if io::stdin().is_terminal() {
+    if interactive {
         write!(stdout, "Paste Anthropic API key (will not echo): ")?;
         stdout.flush()?;
     }
@@ -204,7 +206,8 @@ mod tests {
     fn dispatch_to_string(backend: &MemoryBackend, action: WarmAction, stdin: &str) -> String {
         let mut out = Vec::new();
         let mut input = stdin.as_bytes();
-        dispatch(backend, action, &mut input, &mut out).expect("dispatch");
+        dispatch_with_env(backend, action, &mut input, &mut out, false, |_| None)
+            .expect("dispatch");
         String::from_utf8(out).expect("utf8")
     }
 
@@ -240,11 +243,13 @@ mod tests {
         let backend = MemoryBackend::new();
         let mut out = Vec::new();
         let mut input = "\n".as_bytes();
-        let err = dispatch(
+        let err = dispatch_with_env(
             &backend,
             WarmAction::SetKey { from_env: None },
             &mut input,
             &mut out,
+            false,
+            |_| None,
         )
         .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -263,6 +268,7 @@ mod tests {
             },
             &mut input,
             &mut out,
+            false,
             |v| (v == "ANTHROPIC_API_KEY").then(|| "sk-ant-from-env".to_string()),
         )
         .expect("dispatch");
@@ -283,10 +289,29 @@ mod tests {
             },
             &mut input,
             &mut out,
+            false,
             |_| None,
         )
         .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn read_key_from_stdin_does_not_prompt_when_non_interactive() {
+        let mut input = "sk-ant-direct\n".as_bytes();
+        let mut out = Vec::new();
+        let raw = read_key_from_stdin(false, &mut input, &mut out).expect("read");
+        assert_eq!(raw.trim(), "sk-ant-direct");
+        assert!(out.is_empty(), "non-interactive must not print a prompt");
+    }
+
+    #[test]
+    fn read_key_from_stdin_prompts_when_interactive() {
+        let mut input = "sk-ant-direct\n".as_bytes();
+        let mut out = Vec::new();
+        read_key_from_stdin(true, &mut input, &mut out).expect("read");
+        let prompt = String::from_utf8(out).unwrap();
+        assert!(prompt.contains("Paste"), "interactive must print a prompt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First slice of the MVP3 cache-warming daemon (umbrella #17). Closes #18 and lands the scaffolding portion of #22; remaining MVP3 sub-issues (#19/#20/#21/#23) plug into this surface without renaming or moving anything.

**#18 — Secret storage**
- `src/secrets.rs` — `SecretBackend` trait, `KeyringBackend` (real OS keychain via `keyring` crate), `MemoryBackend` (`#[cfg(test)]` only).
- Public API: `set_api_key` / `get_api_key` / `remove_api_key` / `has_api_key` / `redact_key`. Empty/whitespace-only keys are rejected at the convenience layer.
- `redact_key` shows at most a 9-char prefix (`sk-ant-ap…`); inputs ≤10 chars are fully redacted (`…`). `check-key` never echoes the full key.
- Cross-platform via keyring 3.x features `apple-native` / `windows-native` / `sync-secret-service`, with `crypto-rust` to avoid the OpenSSL build dep on Linux.

**#22 — `duru warm` CLI scaffold**
- New `TopCommand::Warm { action }` mirroring the `Hooks` pattern.
- `WarmAction` covers all eight subcommands listed in the umbrella (`set-key` / `check-key` / `unset-key` / `dry-run` / `install` / `uninstall` / `daemon` / `status`).
- Live handlers: `set-key` (stdin or `--from-env VAR`; never positional), `check-key`, `unset-key`, and `status` (key state + daemon stub + recent-pings stub).
- Stub handlers for `dry-run` / `install` / `uninstall` / `daemon` print a single `(MVP3 #N)` line; the issue numbers live in `const ISSUE_*` so a renumber stays in one place.
- `preflight` enforces \"hooks not installed — run \`duru hooks install\` first\" by checking `hooks_install::registry_dir`. Without the registry there's nothing to warm.

**Tests / quality gates**
- 34 new tests (10 secrets + 13 warm dispatch + 11 main parsing). Total **246 passed, 0 failed**.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.
- `dispatch_with_env` injects an env-lookup closure so the `--from-env` path is exercised without `unsafe { std::env::set_var }` (the precise reason Rust 2024 made that API unsafe).

## Out of scope (deliberately deferred)

| Issue | Reason |
|---|---|
| #19 prefix reconstruction | Highest technical risk in MVP3. Lands as its own PR with empirical `cache_read_input_tokens > 0` verification on a real session. |
| #20 warming policy | Depends on a working dry-run from #19. |
| #21 daemon lifecycle | Needs the warming loop body before launchd/systemd wrapping is meaningful. |
| #23 observability | Consumes the daemon's emitted events; nothing to log yet. |

## Test plan

Automated:
- [x] `cargo fmt --check`
- [x] `cargo test` — 241 unit + 5 integration, all green
- [x] `cargo clippy --all-targets -- -D warnings`

Manual smoke (run after merging hooks-install on the test machine):
- [ ] `duru warm check-key` → `api key: not configured`
- [ ] `duru warm set-key` (paste a sandbox key via stdin) → `api key stored in keychain`
- [ ] `duru warm check-key` → `api key: configured (sk-ant-ap…)` — prefix only, no leak
- [ ] `duru warm set-key sk-ant-positional` → clap rejects positional
- [ ] `duru warm unset-key` → `api key removed`; second call still succeeds (idempotent)
- [ ] `duru warm dry-run abc` → `dry-run abc: prefix reconstruction (MVP3 #19)`
- [ ] `duru warm install` / `daemon` / `uninstall` → stub messages, exit 0
- [ ] In a temp `HOME` without `~/.claude/duru/registry/` → `hooks not installed — run \`duru hooks install\` first`
- [ ] On Linux without Secret Service available → `KeyringBackend` returns a clear `keyring: ...` error rather than panicking

## References

- Umbrella: #17
- This PR closes #18, partially addresses #22.