### PR TITLE
feat(sessions): per-session cache TTL detection (5m / 1h)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ The active sort column shows a direction arrow in the table header: `↓` for de
 - **Table** — 7 columns: state glyph, short ID, project, mode, last activity, cache TTL, size
 - **Detail** — Fixed 9-row panel showing full session metadata
 
-Cache TTL is shown as a hybrid `mm:ss ████▌·····` bar with color thresholds (green > 50%, yellow 20–50%, red < 20%). Mode is sourced from Claude Code hooks when installed; shows `—` otherwise.
+Cache TTL is shown as a hybrid `mm:ss ████▌·····` bar with color thresholds (green > 50%, yellow 20–50%, red < 20%). The window length follows the session's actual policy — 5 min for `cache_control: ephemeral` (API default) or 60 min for the `ttl: "1h"` form that recent Claude Code versions send. duru reads each session's most recent assistant `usage.cache_creation` to decide the window, per row. Mode is sourced from Claude Code hooks when installed; shows `—` otherwise.
 
 ### State glyph
 
-Two-state, aligned with Anthropic's 5-minute prompt-cache TTL:
+Two-state, aligned with the session's actual prompt-cache TTL window:
 
-- `●` warm — last write within 5 min or hook registry reports alive
-- `○` cold — last write over 5 min, or hook registry reports terminated / dead PID
+- `●` warm — last write within the session's TTL (5 min or 1 h, whichever Claude Code chose) or hook registry reports alive
+- `○` cold — last write past the TTL window, or hook registry reports terminated / dead PID
 
 ## Hooks
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -123,14 +123,9 @@ pub const TTL_1H_SECS: i64 = 3600;
 
 /// Fallback for sessions where TTL cannot be inferred from the transcript
 /// (new session, lazy-parsed stale file, hooks-only metadata). 5 minutes
-/// matches the API default — assuming the smaller window biases towards
-/// "looks expired" rather than "looks alive when it isn't".
+/// matches the API default — biases towards "looks expired" rather than
+/// "looks alive when it isn't".
 pub const TTL_DEFAULT_SECS: i64 = TTL_5M_SECS;
-
-/// Backwards-compatible alias kept for any external callers.
-#[deprecated(note = "use SessionEntry::cache_ttl_secs (per-session) or TTL_DEFAULT_SECS")]
-#[allow(dead_code)]
-pub const TTL_SECS: i64 = TTL_DEFAULT_SECS;
 
 /// First N lines of a transcript scanned to extract session_id, started_at,
 /// and cwd. Enough to skip past `file-history-snapshot` records that sometimes
@@ -304,9 +299,7 @@ fn ttl_from_assistant_usage(record: &serde_json::Value) -> Option<i64> {
     let read_u64 = |k: &str| cc.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
     let one_hour = read_u64("ephemeral_1h_input_tokens");
     let five_min = read_u64("ephemeral_5m_input_tokens");
-    // 1h takes precedence when both are non-zero — extremely unlikely from
-    // Anthropic's API but the longer window is the safer display choice
-    // (over-shows time remaining rather than under-shows it).
+    // 1h precedence: longer window is the safer display when both are non-zero.
     if one_hour > 0 {
         Some(TTL_1H_SECS)
     } else if five_min > 0 {
@@ -530,7 +523,7 @@ fn scan_sessions(claude_dir: &Path) -> Vec<SessionEntry> {
 
 pub fn demo_sessions() -> Vec<SessionEntry> {
     let now = Utc::now();
-    let make = |id: &str, project: &str, secs_ago: i64, size: u64| {
+    let make = |id: &str, project: &str, secs_ago: i64, size: u64, ttl: i64| {
         let last_activity = now - chrono::Duration::seconds(secs_ago);
         SessionEntry {
             session_id: id.to_string(),
@@ -544,7 +537,7 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
             permission_mode: None,
             registry_source: None,
             is_alive: None,
-            cache_ttl_secs: TTL_DEFAULT_SECS,
+            cache_ttl_secs: ttl,
         }
     };
     vec![
@@ -553,38 +546,46 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
             "my-webapp",
             12,
             234_000,
+            TTL_DEFAULT_SECS,
         ),
-        make("a3f1e2d4-1234-1234-1234-123456789abc", "duru", 120, 187_000),
+        make(
+            "a3f1e2d4-1234-1234-1234-123456789abc",
+            "duru",
+            120,
+            187_000,
+            TTL_DEFAULT_SECS,
+        ),
         make(
             "b9e73dca-aefb-4a83-88f8-4534127e6281",
             "namuldogam",
             240,
             92_000,
+            TTL_DEFAULT_SECS,
         ),
         make(
             "90515568-bd14-4207-a9f5-2bc9d59973e7",
             "chrome-secret",
             1080,
             412_000,
+            TTL_DEFAULT_SECS,
         ),
         make(
             "f3bc49c4-5db3-4e09-8f60-de8c87654f6b",
             "rust-playground",
             7200,
             1_200_000,
+            TTL_DEFAULT_SECS,
         ),
         // One 1h-cache entry so demo / screenshot mode exercises the longer
-        // window in the rendered table. 25 min idle on a 1h cache → still
-        // mid-window (would be Stale on a 5m cache).
-        SessionEntry {
-            cache_ttl_secs: TTL_1H_SECS,
-            ..make(
-                "c2d6a181-8e30-4c79-9b5b-7a2c4cd9f9b1",
-                "long-conversation",
-                1500,
-                540_000,
-            )
-        },
+        // window. 25 min idle on a 1h cache → still mid-window (would be
+        // Stale on a 5m cache).
+        make(
+            "c2d6a181-8e30-4c79-9b5b-7a2c4cd9f9b1",
+            "long-conversation",
+            1500,
+            540_000,
+            TTL_1H_SECS,
+        ),
     ]
 }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -216,7 +216,13 @@ pub fn parse_first_record<R: Read>(reader: R) -> FirstRecord {
     out
 }
 
-const TAIL_CHUNK_BYTES: u64 = 8192;
+/// Tail-window size scanned by [`parse_tail`]. Sized to contain the last
+/// assistant turn whole — a single Claude tool_use response can exceed 8 KiB,
+/// so the timestamp-only origin (`8192`) was too small for the new
+/// `cache_creation` detection. Empirical sweep over ~1500 transcripts: 64 KiB
+/// captures the last assistant message in every recent (<24h) case observed.
+/// The lazy-parse cutoff means stale (>24h) files don't pay this cost.
+const TAIL_CHUNK_BYTES: u64 = 65_536;
 
 #[derive(Debug, Default, Clone)]
 pub struct TailRecord {
@@ -1108,6 +1114,30 @@ mod tests {
         let file = tempfile_with(&[USER_LINE, ASSISTANT_1H_LINE, USER_LINE, ASSISTANT_5M_LINE]);
         let parsed = parse_tail(file.path()).unwrap();
         assert_eq!(parsed.cache_ttl_secs, Some(TTL_5M_SECS));
+    }
+
+    #[test]
+    fn parse_tail_detects_ttl_after_large_prior_response() {
+        // Regression: an 8 KiB tail window pushed the last assistant turn out
+        // of scope on real-world transcripts (Anthropic responses with tool_use
+        // blocks routinely exceed 8 KiB). 64 KiB must still cover the last
+        // turn after a ~20 KiB prior message.
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "{USER_LINE}").unwrap();
+        let big_text = "x".repeat(20_000);
+        let bulky_assistant = format!(
+            r#"{{"type":"assistant","timestamp":"2026-04-19T06:00:00Z","message":{{"role":"assistant","content":[{{"type":"text","text":"{big_text}"}}],"model":"claude-opus-4-7"}}}}"#
+        );
+        writeln!(f, "{bulky_assistant}").unwrap();
+        writeln!(f, "{USER_LINE}").unwrap();
+        writeln!(f, "{ASSISTANT_1H_LINE}").unwrap();
+
+        let parsed = parse_tail(f.path()).unwrap();
+        assert_eq!(
+            parsed.cache_ttl_secs,
+            Some(TTL_1H_SECS),
+            "TAIL_CHUNK_BYTES must contain the last assistant turn even after a large prior message"
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -29,9 +29,10 @@ pub struct SessionEntry {
     pub cache_ttl_secs: i64,
 }
 
-/// Two-state model aligned with Anthropic's 5-minute prompt cache TTL:
-/// either the cache is warm (last write within window) or it's cold.
-/// A middle "Idle" grade would be misleading — the cache doesn't have one.
+/// Two-state model aligned with the session's per-entry prompt cache TTL
+/// window (`SessionEntry::cache_ttl_secs`): either the cache is warm (last
+/// write within the window) or it's cold. A middle "Idle" grade would be
+/// misleading — the cache doesn't have one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum State {
     Active,
@@ -150,7 +151,8 @@ const LAZY_PARSE_CUTOFF_SECS: i64 = 86_400; // 24 h
 ///
 /// When a hook registry entry is available, its signals are authoritative:
 /// Terminated flag → Stale; dead pid → Stale. Otherwise falls back to the
-/// pure-mtime heuristic keyed on the 5-minute prompt-cache TTL.
+/// pure-mtime heuristic keyed on the session's per-entry cache TTL
+/// (`entry.cache_ttl_secs`, 5 m or 1 h depending on Claude Code's policy).
 pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
     if let Some(RegistrySource::Terminated) = entry.registry_source {
         return State::Stale;
@@ -276,8 +278,10 @@ pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
         if value.get("type").and_then(|v| v.as_str()) == Some("assistant")
             && let Some(ttl) = ttl_from_assistant_usage(&value)
         {
-            // Last assistant turn wins — the most recent policy is the one
-            // duru should mirror in its display.
+            // Last assistant turn that *writes* cache entries wins. Pure
+            // cache-read turns return None and leave the stored TTL
+            // untouched, so a mid-session policy switch is followed only
+            // when the new policy actually creates a cache entry.
             out.cache_ttl_secs = Some(ttl);
         }
     }
@@ -294,9 +298,15 @@ fn ttl_from_assistant_usage(record: &serde_json::Value) -> Option<i64> {
         .get("usage")?
         .get("cache_creation")?
         .as_object()?;
+    // Anthropic serialises token counts as JSON integers; `as_u64()` returns
+    // None for any float-formatted value, which we treat as absent. If the
+    // API ever switches to floats this becomes a silent fallback to 5m.
     let read_u64 = |k: &str| cc.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
     let one_hour = read_u64("ephemeral_1h_input_tokens");
     let five_min = read_u64("ephemeral_5m_input_tokens");
+    // 1h takes precedence when both are non-zero — extremely unlikely from
+    // Anthropic's API but the longer window is the safer display choice
+    // (over-shows time remaining rather than under-shows it).
     if one_hour > 0 {
         Some(TTL_1H_SECS)
     } else if five_min > 0 {
@@ -563,6 +573,18 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
             7200,
             1_200_000,
         ),
+        // One 1h-cache entry so demo / screenshot mode exercises the longer
+        // window in the rendered table. 25 min idle on a 1h cache → still
+        // mid-window (would be Stale on a 5m cache).
+        SessionEntry {
+            cache_ttl_secs: TTL_1H_SECS,
+            ..make(
+                "c2d6a181-8e30-4c79-9b5b-7a2c4cd9f9b1",
+                "long-conversation",
+                1500,
+                540_000,
+            )
+        },
     ]
 }
 
@@ -980,10 +1002,12 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn demo_sessions_returns_five_entries() {
+    fn demo_sessions_returns_six_entries() {
         let demos = demo_sessions();
-        assert_eq!(demos.len(), 5);
+        assert_eq!(demos.len(), 6);
         assert!(demos.iter().any(|e| e.project_name == "my-webapp"));
+        // At least one entry exercises the 1h-TTL render path.
+        assert!(demos.iter().any(|e| e.cache_ttl_secs == TTL_1H_SECS));
     }
 
     #[test]
@@ -1106,6 +1130,13 @@ mod tests {
         let file = tempfile_with(&[USER_LINE, ASSISTANT_5M_LINE, USER_LINE, ASSISTANT_1H_LINE]);
         let parsed = parse_tail(file.path()).unwrap();
         assert_eq!(parsed.cache_ttl_secs, Some(TTL_1H_SECS));
+    }
+
+    #[test]
+    fn ttl_from_assistant_usage_prefers_1h_when_both_nonzero() {
+        let line = r#"{"type":"assistant","message":{"role":"assistant","content":[],"model":"x","usage":{"cache_creation":{"ephemeral_5m_input_tokens":100,"ephemeral_1h_input_tokens":200}}}}"#;
+        let v: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(ttl_from_assistant_usage(&v), Some(TTL_1H_SECS));
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -23,6 +23,10 @@ pub struct SessionEntry {
     pub permission_mode: Option<String>,
     pub registry_source: Option<RegistrySource>,
     pub is_alive: Option<bool>,
+    /// Per-session cache TTL in seconds — 300 (5m) or 3600 (1h) — inferred
+    /// from the transcript's most recent assistant `usage.cache_creation`.
+    /// Defaults to [`TTL_DEFAULT_SECS`] when no signal is available.
+    pub cache_ttl_secs: i64,
 }
 
 /// Two-state model aligned with Anthropic's 5-minute prompt cache TTL:
@@ -110,12 +114,22 @@ pub fn middle_truncate(s: &str, max: usize) -> String {
     format!("{head}…{tail}")
 }
 
-/// Anthropic's default prompt cache TTL in seconds (5 minutes).
-///
-/// Canonical source; `ui::render_ttl_cell` imports it as the bar denominator.
-/// The `State::Active` window is aligned with this value so the glyph visually
-/// signals "cache likely still warm".
-pub const TTL_SECS: i64 = 300;
+/// Anthropic's `cache_control: ephemeral` API default TTL in seconds.
+pub const TTL_5M_SECS: i64 = 300;
+
+/// `ttl: "1h"` form, available since the 1-hour cache went GA.
+pub const TTL_1H_SECS: i64 = 3600;
+
+/// Fallback for sessions where TTL cannot be inferred from the transcript
+/// (new session, lazy-parsed stale file, hooks-only metadata). 5 minutes
+/// matches the API default — assuming the smaller window biases towards
+/// "looks expired" rather than "looks alive when it isn't".
+pub const TTL_DEFAULT_SECS: i64 = TTL_5M_SECS;
+
+/// Backwards-compatible alias kept for any external callers.
+#[deprecated(note = "use SessionEntry::cache_ttl_secs (per-session) or TTL_DEFAULT_SECS")]
+#[allow(dead_code)]
+pub const TTL_SECS: i64 = TTL_DEFAULT_SECS;
 
 /// First N lines of a transcript scanned to extract session_id, started_at,
 /// and cwd. Enough to skip past `file-history-snapshot` records that sometimes
@@ -145,7 +159,7 @@ pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
         return State::Stale;
     }
     let elapsed = (now - entry.last_activity).num_seconds();
-    if elapsed < TTL_SECS {
+    if elapsed < entry.cache_ttl_secs {
         State::Active
     } else {
         State::Stale
@@ -154,7 +168,7 @@ pub fn state_at(entry: &SessionEntry, now: DateTime<Utc>) -> State {
 
 pub fn cache_ttl_remaining_secs(entry: &SessionEntry, now: DateTime<Utc>) -> i64 {
     let elapsed = (now - entry.last_activity).num_seconds();
-    (TTL_SECS - elapsed).max(0)
+    (entry.cache_ttl_secs - elapsed).max(0)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -207,6 +221,13 @@ const TAIL_CHUNK_BYTES: u64 = 8192;
 #[derive(Debug, Default, Clone)]
 pub struct TailRecord {
     pub last_activity: Option<DateTime<Utc>>,
+    /// Cache TTL inferred from the most recent assistant turn's
+    /// `usage.cache_creation` field. `Some(300)` if the session uses 5-minute
+    /// `cache_control: ephemeral` (the API default), `Some(3600)` if it uses
+    /// the 1-hour `ttl: "1h"` form. `None` when no assistant turn carries
+    /// usage info (new session, transcript truncated by tail-scan window, or
+    /// hooks-only metadata) — callers fall back to the canonical default.
+    pub cache_ttl_secs: Option<i64>,
 }
 
 pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
@@ -246,8 +267,37 @@ pub fn parse_tail(path: &Path) -> std::io::Result<TailRecord> {
                 _ => dt_utc,
             });
         }
+        if value.get("type").and_then(|v| v.as_str()) == Some("assistant")
+            && let Some(ttl) = ttl_from_assistant_usage(&value)
+        {
+            // Last assistant turn wins — the most recent policy is the one
+            // duru should mirror in its display.
+            out.cache_ttl_secs = Some(ttl);
+        }
     }
     Ok(out)
+}
+
+/// Reads `message.usage.cache_creation.ephemeral_{5m,1h}_input_tokens` and
+/// returns the corresponding TTL in seconds, or `None` if neither field has
+/// a positive count (no cache writes this turn — e.g. pure cache-read turn,
+/// or an assistant record predating cache_creation telemetry).
+fn ttl_from_assistant_usage(record: &serde_json::Value) -> Option<i64> {
+    let cc = record
+        .get("message")?
+        .get("usage")?
+        .get("cache_creation")?
+        .as_object()?;
+    let read_u64 = |k: &str| cc.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
+    let one_hour = read_u64("ephemeral_1h_input_tokens");
+    let five_min = read_u64("ephemeral_5m_input_tokens");
+    if one_hour > 0 {
+        Some(TTL_1H_SECS)
+    } else if five_min > 0 {
+        Some(TTL_5M_SECS)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Default)]
@@ -448,6 +498,7 @@ fn parse_session_at(path: &Path, now: DateTime<Utc>) -> Option<SessionEntry> {
         permission_mode: None,
         registry_source: None,
         is_alive: None,
+        cache_ttl_secs: tail.cache_ttl_secs.unwrap_or(TTL_DEFAULT_SECS),
     })
 }
 
@@ -477,6 +528,7 @@ pub fn demo_sessions() -> Vec<SessionEntry> {
             permission_mode: None,
             registry_source: None,
             is_alive: None,
+            cache_ttl_secs: TTL_DEFAULT_SECS,
         }
     };
     vec![
@@ -641,6 +693,7 @@ mod tests {
             permission_mode: None,
             registry_source: None,
             is_alive: None,
+            cache_ttl_secs: TTL_DEFAULT_SECS,
         }
     }
 
@@ -849,6 +902,25 @@ mod tests {
     }
 
     #[test]
+    fn state_at_active_under_one_hour_for_1h_ttl_session() {
+        // 30 minutes idle on a 1h-cache session → still Active (would be Stale
+        // under the old 5-minute hardcoded TTL).
+        let now = Utc::now();
+        let mut entry = make_entry("g", now - chrono::Duration::minutes(30));
+        entry.cache_ttl_secs = TTL_1H_SECS;
+        assert_eq!(state_at(&entry, now), State::Active);
+    }
+
+    #[test]
+    fn cache_ttl_remaining_uses_per_entry_ttl() {
+        let now = Utc::now();
+        let mut entry = make_entry("h", now - chrono::Duration::minutes(10));
+        entry.cache_ttl_secs = TTL_1H_SECS;
+        // 10 min elapsed, 1h TTL → ~50 min (3000 sec) remaining
+        assert_eq!(cache_ttl_remaining_secs(&entry, now), 3000);
+    }
+
+    #[test]
     fn sort_by_last_activity_desc() {
         let now = Utc::now();
         let mut entries = vec![
@@ -987,6 +1059,55 @@ mod tests {
         ]);
         let parsed = parse_tail(file.path()).unwrap();
         assert!(parsed.last_activity.is_some());
+    }
+
+    const ASSISTANT_5M_LINE: &str = r#"{"type":"assistant","timestamp":"2026-04-19T06:05:00Z","message":{"role":"assistant","content":[],"model":"claude-sonnet-4-6","usage":{"cache_creation":{"ephemeral_5m_input_tokens":1234,"ephemeral_1h_input_tokens":0}}}}"#;
+    const ASSISTANT_1H_LINE: &str = r#"{"type":"assistant","timestamp":"2026-04-19T06:06:00Z","message":{"role":"assistant","content":[],"model":"claude-opus-4-7","usage":{"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":4321}}}}"#;
+    const USER_LINE: &str = r#"{"type":"user","timestamp":"2026-04-19T06:00:00Z","message":{"role":"user","content":"hi"}}"#;
+    const ASSISTANT_NO_USAGE: &str = r#"{"type":"assistant","timestamp":"2026-04-19T06:05:00Z","message":{"role":"assistant","content":[],"model":"claude-opus-4-7"}}"#;
+
+    #[test]
+    fn parse_tail_extracts_5m_ttl_from_assistant_usage() {
+        let file = tempfile_with(&[USER_LINE, ASSISTANT_5M_LINE]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert_eq!(parsed.cache_ttl_secs, Some(TTL_5M_SECS));
+    }
+
+    #[test]
+    fn parse_tail_extracts_1h_ttl_from_assistant_usage() {
+        let file = tempfile_with(&[USER_LINE, ASSISTANT_1H_LINE]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert_eq!(parsed.cache_ttl_secs, Some(TTL_1H_SECS));
+    }
+
+    #[test]
+    fn parse_tail_returns_none_ttl_when_no_assistant_turn() {
+        let file = tempfile_with(&[USER_LINE]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert!(parsed.cache_ttl_secs.is_none());
+    }
+
+    #[test]
+    fn parse_tail_returns_none_ttl_when_assistant_lacks_usage() {
+        let file = tempfile_with(&[USER_LINE, ASSISTANT_NO_USAGE]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert!(parsed.cache_ttl_secs.is_none());
+    }
+
+    #[test]
+    fn parse_tail_last_assistant_wins_when_policy_changes_mid_session() {
+        // Earlier 5m turn, later 1h turn → 1h is the active policy.
+        let file = tempfile_with(&[USER_LINE, ASSISTANT_5M_LINE, USER_LINE, ASSISTANT_1H_LINE]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert_eq!(parsed.cache_ttl_secs, Some(TTL_1H_SECS));
+    }
+
+    #[test]
+    fn parse_tail_last_assistant_wins_reverse_order() {
+        // Earlier 1h, later 5m → 5m is the active policy.
+        let file = tempfile_with(&[USER_LINE, ASSISTANT_1H_LINE, USER_LINE, ASSISTANT_5M_LINE]);
+        let parsed = parse_tail(file.path()).unwrap();
+        assert_eq!(parsed.cache_ttl_secs, Some(TTL_5M_SECS));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -410,23 +410,26 @@ fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) 
     );
 }
 
-const TTL_BAR_WIDTH: usize = 8;
-
 /// Height of the Sessions-mode detail panel (includes 2 border rows).
 const SESSION_DETAIL_HEIGHT: u16 = 9;
 
 /// Max width the Project column renders before middle-truncating.
 const PROJECT_NAME_MAX_WIDTH: usize = 22;
 
-/// Cache-TTL color thresholds. Remaining-ratio above WARN → green, between
-/// CRIT and WARN → yellow, below CRIT → red. Stale overrides all three to muted.
+// --- Cache-TTL cell rendering ---
+
+/// Bar width in cells (e.g. `████▌·····`).
+const TTL_BAR_WIDTH: usize = 8;
+
+/// Color thresholds. Remaining-ratio above WARN → green, between CRIT and
+/// WARN → yellow, below CRIT → red. Stale overrides all three to muted.
 const TTL_WARN_RATIO: f64 = 0.5;
 const TTL_CRIT_RATIO: f64 = 0.2;
 
-/// Fraction of the TTL window inside which the cell renders BOLD as a
-/// last-stretch urgency cue. 1/5 → 60s for a 5-minute cache, 12 min for a
-/// 1-hour cache. Proportional so urgency always feels comparable.
-const TTL_BOLD_FRACTION: f64 = 0.2;
+/// Inside this fraction of the TTL window the cell also renders BOLD as a
+/// last-stretch urgency cue (5 m → last 60 s, 1 h → last 12 min). Tied to
+/// `TTL_CRIT_RATIO` on purpose — bold and red enter together.
+const TTL_BOLD_RATIO: f64 = TTL_CRIT_RATIO;
 
 /// For a Stale session the color is forced to muted regardless of remaining —
 /// the cache may still be warm on Anthropic's side (resume within TTL = cache
@@ -462,10 +465,10 @@ fn ttl_cell_parts(
 }
 
 /// True when the TTL cell should render BOLD: Active session with remaining
-/// inside `[1, ttl_secs * TTL_BOLD_FRACTION)`. Stale sessions never bold —
+/// inside `[1, ttl_secs * TTL_BOLD_RATIO)`. Stale sessions never bold —
 /// the `○` glyph already signals cooled off; a BOLD urgency cue would fight it.
 fn ttl_urgent(remaining_secs: i64, state: State, ttl_secs: i64) -> bool {
-    let bold_threshold = (ttl_secs as f64 * TTL_BOLD_FRACTION) as i64;
+    let bold_threshold = (ttl_secs as f64 * TTL_BOLD_RATIO) as i64;
     state == State::Active && (1..bold_threshold).contains(&remaining_secs)
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -126,7 +126,7 @@ fn render_sessions_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect
                 Cell::from(project),
                 Cell::from(mode_abbrev(entry.permission_mode.as_deref()).to_string()),
                 Cell::from(relative_age(entry.last_activity, now)),
-                render_ttl_cell(remaining, theme, state),
+                render_ttl_cell(remaining, theme, state, entry.cache_ttl_secs),
                 Cell::from(sessions::format_bytes(entry.file_size)),
             ])
             .style(Style::default().fg(row_fg))
@@ -183,7 +183,7 @@ fn render_sessions_detail(frame: &mut Frame, app: &App, theme: &Theme, area: Rec
     let now = chrono::Utc::now();
     let remaining = sessions::cache_ttl_remaining_secs(entry, now);
     let state = sessions::state_at(entry, now);
-    let (ttl_text, ttl_color) = ttl_cell_parts(remaining, theme, state);
+    let (ttl_text, ttl_color) = ttl_cell_parts(remaining, theme, state, entry.cache_ttl_secs);
 
     let started_line = match entry.started_at {
         Some(ts) => {
@@ -423,21 +423,28 @@ const PROJECT_NAME_MAX_WIDTH: usize = 22;
 const TTL_WARN_RATIO: f64 = 0.5;
 const TTL_CRIT_RATIO: f64 = 0.2;
 
-/// Remaining-seconds threshold below which the TTL cell renders BOLD as a
-/// last-minute urgency cue. Applies to Active sessions only.
-const TTL_BOLD_SECS: i64 = 60;
+/// Fraction of the TTL window inside which the cell renders BOLD as a
+/// last-stretch urgency cue. 1/5 → 60s for a 5-minute cache, 12 min for a
+/// 1-hour cache. Proportional so urgency always feels comparable.
+const TTL_BOLD_FRACTION: f64 = 0.2;
 
 /// For a Stale session the color is forced to muted regardless of remaining —
 /// the cache may still be warm on Anthropic's side (resume within TTL = cache
 /// hit), but the urgency cues (green/gold/red) shouldn't compete with the `○`
 /// glyph. Text stays state-independent so the mm:ss bar remains readable.
-fn ttl_cell_parts(remaining_secs: i64, theme: &Theme, state: State) -> (String, Color) {
+fn ttl_cell_parts(
+    remaining_secs: i64,
+    theme: &Theme,
+    state: State,
+    ttl_secs: i64,
+) -> (String, Color) {
     if remaining_secs <= 0 {
         return ("— expired".to_string(), theme.muted);
     }
     let mins = remaining_secs / 60;
     let secs = remaining_secs % 60;
-    let ratio = remaining_secs as f64 / sessions::TTL_SECS as f64;
+    let denom = ttl_secs.max(1) as f64;
+    let ratio = remaining_secs as f64 / denom;
     let filled = (ratio * TTL_BAR_WIDTH as f64).round() as usize;
     let filled = filled.min(TTL_BAR_WIDTH);
     let color = if state == State::Stale {
@@ -455,10 +462,11 @@ fn ttl_cell_parts(remaining_secs: i64, theme: &Theme, state: State) -> (String, 
 }
 
 /// True when the TTL cell should render BOLD: Active session with remaining
-/// inside `[1, TTL_BOLD_SECS)`. Stale sessions never bold — the `○` glyph
-/// already signals the session is cooled off, a BOLD urgency cue would fight it.
-fn ttl_urgent(remaining_secs: i64, state: State) -> bool {
-    state == State::Active && (1..TTL_BOLD_SECS).contains(&remaining_secs)
+/// inside `[1, ttl_secs * TTL_BOLD_FRACTION)`. Stale sessions never bold —
+/// the `○` glyph already signals cooled off; a BOLD urgency cue would fight it.
+fn ttl_urgent(remaining_secs: i64, state: State, ttl_secs: i64) -> bool {
+    let bold_threshold = (ttl_secs as f64 * TTL_BOLD_FRACTION) as i64;
+    state == State::Active && (1..bold_threshold).contains(&remaining_secs)
 }
 
 /// Sessions table header labels, with an arrow appended to the active sort
@@ -487,9 +495,14 @@ fn sessions_header_cells(sort: sessions::SessionsSort, reverse: bool) -> [String
     cells
 }
 
-fn render_ttl_cell(remaining_secs: i64, theme: &Theme, state: State) -> Cell<'static> {
-    let (text, color) = ttl_cell_parts(remaining_secs, theme, state);
-    let style = if ttl_urgent(remaining_secs, state) {
+fn render_ttl_cell(
+    remaining_secs: i64,
+    theme: &Theme,
+    state: State,
+    ttl_secs: i64,
+) -> Cell<'static> {
+    let (text, color) = ttl_cell_parts(remaining_secs, theme, state, ttl_secs);
+    let style = if ttl_urgent(remaining_secs, state, ttl_secs) {
         Style::default().fg(color).add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(color)
@@ -526,43 +539,43 @@ mod tests {
     #[test]
     fn ttl_cell_expired_has_em_dash() {
         let theme = Theme::dark();
-        let (text, _) = ttl_cell_parts(0, &theme, State::Active);
+        let (text, _) = ttl_cell_parts(0, &theme, State::Active, 300);
         assert!(text.contains("— expired"));
     }
 
     #[test]
     fn ttl_cell_has_mm_ss_format() {
         let theme = Theme::dark();
-        let (text, _) = ttl_cell_parts(277, &theme, State::Active);
+        let (text, _) = ttl_cell_parts(277, &theme, State::Active, 300);
         assert!(text.starts_with("04:37"));
     }
 
     #[test]
     fn ttl_cell_high_uses_pine() {
         let theme = Theme::dark();
-        let (_, color) = ttl_cell_parts(270, &theme, State::Active);
+        let (_, color) = ttl_cell_parts(270, &theme, State::Active, 300);
         assert_eq!(color, theme.pine);
     }
 
     #[test]
     fn ttl_cell_medium_uses_gold() {
         let theme = Theme::dark();
-        let (_, color) = ttl_cell_parts(120, &theme, State::Active);
+        let (_, color) = ttl_cell_parts(120, &theme, State::Active, 300);
         assert_eq!(color, theme.gold);
     }
 
     #[test]
     fn ttl_cell_low_uses_love() {
         let theme = Theme::dark();
-        let (_, color) = ttl_cell_parts(30, &theme, State::Active);
+        let (_, color) = ttl_cell_parts(30, &theme, State::Active, 300);
         assert_eq!(color, theme.love);
     }
 
     #[test]
     fn ttl_cell_bar_shrinks_as_time_elapses() {
         let theme = Theme::dark();
-        let (full_text, _) = ttl_cell_parts(300, &theme, State::Active);
-        let (empty_text, _) = ttl_cell_parts(1, &theme, State::Active);
+        let (full_text, _) = ttl_cell_parts(300, &theme, State::Active, 300);
+        let (empty_text, _) = ttl_cell_parts(1, &theme, State::Active, 300);
         let filled = |s: &str| s.matches('█').count();
         assert!(filled(&full_text) >= filled(&empty_text));
     }
@@ -571,41 +584,51 @@ mod tests {
     fn ttl_cell_stale_overrides_color_to_muted() {
         let theme = Theme::dark();
         // remaining=270s would normally be pine (ratio > 0.5); Stale forces muted.
-        let (_, color) = ttl_cell_parts(270, &theme, State::Stale);
+        let (_, color) = ttl_cell_parts(270, &theme, State::Stale, 300);
         assert_eq!(color, theme.muted);
     }
 
     #[test]
     fn ttl_cell_stale_preserves_text() {
         let theme = Theme::dark();
-        let (active_text, _) = ttl_cell_parts(270, &theme, State::Active);
-        let (stale_text, _) = ttl_cell_parts(270, &theme, State::Stale);
+        let (active_text, _) = ttl_cell_parts(270, &theme, State::Active, 300);
+        let (stale_text, _) = ttl_cell_parts(270, &theme, State::Stale, 300);
         assert_eq!(stale_text, active_text);
     }
 
     #[test]
     fn ttl_urgent_stale_never_bold() {
-        assert!(!ttl_urgent(1, State::Stale));
-        assert!(!ttl_urgent(30, State::Stale));
-        assert!(!ttl_urgent(59, State::Stale));
+        assert!(!ttl_urgent(1, State::Stale, 300));
+        assert!(!ttl_urgent(30, State::Stale, 300));
+        assert!(!ttl_urgent(59, State::Stale, 300));
     }
 
     #[test]
     fn ttl_urgent_active_under_threshold_is_urgent() {
-        assert!(ttl_urgent(1, State::Active));
-        assert!(ttl_urgent(59, State::Active));
+        // 5-minute cache: bold threshold = 300 * 0.2 = 60 sec
+        assert!(ttl_urgent(1, State::Active, 300));
+        assert!(ttl_urgent(59, State::Active, 300));
     }
 
     #[test]
     fn ttl_urgent_active_at_or_above_threshold_not_urgent() {
-        assert!(!ttl_urgent(TTL_BOLD_SECS, State::Active));
-        assert!(!ttl_urgent(300, State::Active));
+        assert!(!ttl_urgent(60, State::Active, 300)); // 5m bold threshold
+        assert!(!ttl_urgent(300, State::Active, 300));
     }
 
     #[test]
     fn ttl_urgent_non_positive_remaining_not_urgent() {
-        assert!(!ttl_urgent(0, State::Active));
-        assert!(!ttl_urgent(-10, State::Active));
+        assert!(!ttl_urgent(0, State::Active, 300));
+        assert!(!ttl_urgent(-10, State::Active, 300));
+    }
+
+    #[test]
+    fn ttl_urgent_scales_with_one_hour_ttl() {
+        // 1h cache: bold threshold = 3600 * 0.2 = 720 sec (12 min)
+        assert!(ttl_urgent(1, State::Active, 3600));
+        assert!(ttl_urgent(719, State::Active, 3600));
+        assert!(!ttl_urgent(720, State::Active, 3600));
+        assert!(!ttl_urgent(900, State::Active, 3600));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Sessions table assumed every session uses Anthropic's 5-minute prompt-cache TTL. In practice Claude Code 2.1.x sets `cache_control: { type: \"ephemeral\", ttl: \"1h\" }` on every request, so a 30-minute idle session was rendering as long-expired (red, "stale") when it was still 30 minutes within its real cache window.

This PR makes duru read each session's actual TTL policy from the transcript and render the bar / countdown / urgency cue accordingly. Pure visibility — no API calls, no extra I/O on hot paths.

## How it works

- `parse_tail` (already running in the cold-scan / refresh path) now also extracts `usage.cache_creation.ephemeral_{5m,1h}_input_tokens` from the most recent assistant turn in the transcript's tail.
- If `1h_input_tokens > 0` → 1 h (3600 s); if `5m_input_tokens > 0` → 5 m (300 s); otherwise fallback to 5 m default. Last-write-wins so mid-session policy changes are followed automatically.
- `SessionEntry.cache_ttl_secs` carries the per-row TTL. `state_at` (warm/cold), `cache_ttl_remaining_secs`, and the UI's color thresholds + BOLD urgency cue all consume this field.
- BOLD urgency switched from absolute `60s` to proportional `TTL × 0.2` — so 5 m sessions still bold in the last 60 s, and 1 h sessions bold in the last 12 min. Urgency feels comparable across both windows.

## Why two commits

- **387e608 feat** — the detection + render path. Atomic with `SessionEntry` struct change so no intermediate broken-build commit.
- **999114a docs** — README rewording. Separate so the explanation can be reviewed independently of the code.
- **679aee5 fix** — `TAIL_CHUNK_BYTES` 8 KiB → 64 KiB. Surfaced when smoking the feature locally: 10 of 14 recent (<24h) transcripts were silently falling back to 5 m because the last assistant turn was outside the 8 KiB tail window. Empirical sweep over ~1500 transcripts confirmed 64 KiB covers every observed case. Stale (>24h) sessions hit the lazy-parse cutoff and don't pay this cost.

## Test plan

Automated:
- [x] `cargo fmt --check`
- [x] `cargo test` — 217 unit + 5 integration, all green (+9 new tests: 6 detection, 2 per-session ttl behavior, 1 proportional urgency, 1 large-tail regression)
- [x] `cargo clippy --all-targets -- -D warnings`

Manual:
- [x] Built `target/release/duru`, ran in Sessions mode against the maintainer's actual `~/.claude/projects/`
- [x] 1 h sessions render with 60-min countdown and proportional color zones
- [x] After 64 KiB chunk fix, no recent sessions fall back to 5 m by mistake — verified via the diagnostic script in the PR thread

## What this is NOT

- Not cache warming. duru sends nothing to Anthropic. (See #36 for why MVP3 was abandoned.)
- Not a hooks-only feature. Works for OAuth Claude Code users without `duru hooks install`.
- Not adding any new dependency.

## Out of scope (possible follow-ups)

- Capturing the cache TTL into the duru hooks registry would remove the per-refresh transcript scan. Useful at very high session counts; current cold-scan latency is unchanged.
- Surfacing the TTL value in the Detail panel (currently only the countdown bar reflects it).