### PR TITLE
chore: bump version to v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "duru"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duru"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Terminal dashboard for Claude Code — explore, manage, and monitor your setup"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
v0.4.1 release. Highlights: per-session cache TTL detection (5m / 1h) in Sessions mode (#37). Full notes drafted by release-drafter; manual edit before publish to drop unreleased-revert noise (#36).