### PR TITLE
feat(sessions): jump to project memory with J key

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Press `Tab` to switch between two modes:
 | `S` | Reverse sort direction (toggle asc/desc) |
 | `r` | Force refresh |
 | `g` `G` | Jump to top / bottom |
+| `J` | Jump to selected session's project CLAUDE.md (Memory mode) |
 | `Tab` | Switch to Memory mode |
 | `q` | Quit |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::scan::Project;
+use crate::scan::{FileKind, MemoryFile, Project};
 use crate::sessions::{SessionCache, SessionEntry, SessionsSort};
 
 /// Sessions-mode refresh cadence when any session had activity in the last
@@ -179,8 +179,33 @@ impl App {
                 self.wants_refresh = true;
             }
             KeyCode::Char('r') => self.wants_refresh = true,
+            KeyCode::Char('J') => self.jump_to_project_memory(self.session_index),
             _ => {}
         }
+    }
+
+    /// Jump from a Sessions row to that project's memory in Memory mode.
+    /// Silent no-op if the index is out of range or the project name does
+    /// not match any scanned project (e.g. project deleted while Sessions
+    /// list still has its registry entry).
+    fn jump_to_project_memory(&mut self, session_index: usize) {
+        let Some(entry) = self.sessions.get(session_index) else {
+            return;
+        };
+        let Some(project_idx) = self
+            .projects
+            .iter()
+            .position(|p| p.name == entry.project_name)
+        else {
+            return;
+        };
+        let file_idx = pick_jump_target(&self.projects[project_idx].files);
+
+        self.mode = AppMode::Memory;
+        self.focus = Pane::Preview;
+        self.project_index = project_idx;
+        self.file_index = file_idx;
+        self.load_content();
     }
 
     fn cycle_sort(&mut self) {
@@ -351,6 +376,16 @@ impl App {
             Pane::Preview => Pane::Preview,
         };
     }
+}
+
+/// File priority for the Sessions → Memory jump:
+/// CLAUDE.md (project or global) > MEMORY.md > first file.
+fn pick_jump_target(files: &[MemoryFile]) -> usize {
+    files
+        .iter()
+        .position(|f| matches!(f.kind, FileKind::ProjectClaudeMd | FileKind::GlobalClaudeMd))
+        .or_else(|| files.iter().position(|f| f.kind == FileKind::MemoryIndex))
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -769,5 +804,215 @@ mod tests {
             files: vec![],
         }]);
         assert_eq!(app.selected_file_path(), None);
+    }
+
+    // --- Jump-to-Memory (issue #11) ---
+
+    fn make_jump_test_session(project_name: &str) -> SessionEntry {
+        SessionEntry {
+            session_id: format!("sess-{project_name}"),
+            short_id: format!("s-{project_name}"),
+            project_name: project_name.to_string(),
+            cwd: None,
+            transcript_path: PathBuf::from(format!("/tmp/{project_name}.jsonl")),
+            started_at: None,
+            last_activity: chrono::Utc::now(),
+            file_size: 1000,
+            permission_mode: None,
+            registry_source: None,
+            is_alive: None,
+            cache_ttl_secs: 300,
+        }
+    }
+
+    fn make_jump_test_projects() -> Vec<Project> {
+        vec![
+            Project {
+                name: "GLOBAL".to_string(),
+                path: PathBuf::from("/tmp/jump/global"),
+                files: vec![MemoryFile {
+                    kind: FileKind::GlobalClaudeMd,
+                    path: PathBuf::from("/tmp/jump/global/CLAUDE.md"),
+                    name: "CLAUDE.md".to_string(),
+                    size: 100,
+                }],
+            },
+            // alpha: has CLAUDE.md (should win priority)
+            Project {
+                name: "alpha".to_string(),
+                path: PathBuf::from("/tmp/jump/alpha"),
+                files: vec![
+                    MemoryFile {
+                        kind: FileKind::Memory,
+                        path: PathBuf::from("/tmp/jump/alpha/notes.md"),
+                        name: "notes.md".to_string(),
+                        size: 30,
+                    },
+                    MemoryFile {
+                        kind: FileKind::ProjectClaudeMd,
+                        path: PathBuf::from("/tmp/jump/alpha/CLAUDE.md"),
+                        name: "CLAUDE.md".to_string(),
+                        size: 200,
+                    },
+                ],
+            },
+            // beta: only MEMORY.md (no CLAUDE.md)
+            Project {
+                name: "beta".to_string(),
+                path: PathBuf::from("/tmp/jump/beta"),
+                files: vec![
+                    MemoryFile {
+                        kind: FileKind::Memory,
+                        path: PathBuf::from("/tmp/jump/beta/aaa.md"),
+                        name: "aaa.md".to_string(),
+                        size: 10,
+                    },
+                    MemoryFile {
+                        kind: FileKind::MemoryIndex,
+                        path: PathBuf::from("/tmp/jump/beta/MEMORY.md"),
+                        name: "MEMORY.md".to_string(),
+                        size: 50,
+                    },
+                ],
+            },
+            // gamma: only generic memory files (no CLAUDE.md, no MEMORY.md)
+            Project {
+                name: "gamma".to_string(),
+                path: PathBuf::from("/tmp/jump/gamma"),
+                files: vec![MemoryFile {
+                    kind: FileKind::Memory,
+                    path: PathBuf::from("/tmp/jump/gamma/first.md"),
+                    name: "first.md".to_string(),
+                    size: 20,
+                }],
+            },
+        ]
+    }
+
+    fn app_with_jump_fixture() -> App {
+        let mut app = App::new(make_jump_test_projects());
+        app.sessions = vec![
+            make_jump_test_session("alpha"),       // [0] → projects[1]
+            make_jump_test_session("beta"),        // [1] → projects[2]
+            make_jump_test_session("gamma"),       // [2] → projects[3]
+            make_jump_test_session("GLOBAL"),      // [3] → projects[0]
+            make_jump_test_session("nonexistent"), // [4] → no match
+        ];
+        app.mode = AppMode::Sessions;
+        app
+    }
+
+    #[test]
+    fn jump_switches_to_memory_mode_and_focuses_preview() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 0; // alpha
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Memory);
+        assert_eq!(app.focus, Pane::Preview);
+    }
+
+    #[test]
+    fn jump_picks_project_claude_md_when_present() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 0; // alpha — has CLAUDE.md at file_index 1
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.project_index, 1);
+        // CLAUDE.md is at index 1 in the alpha project (after notes.md at 0)
+        assert_eq!(app.file_index, 1);
+        assert_eq!(
+            app.projects[app.project_index].files[app.file_index].kind,
+            FileKind::ProjectClaudeMd
+        );
+    }
+
+    #[test]
+    fn jump_picks_memory_index_when_no_claude_md() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 1; // beta — has MEMORY.md but no CLAUDE.md
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.project_index, 2);
+        assert_eq!(
+            app.projects[app.project_index].files[app.file_index].kind,
+            FileKind::MemoryIndex
+        );
+    }
+
+    #[test]
+    fn jump_picks_first_file_when_no_claude_or_memory_index() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 2; // gamma — only generic memory files
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.project_index, 3);
+        assert_eq!(app.file_index, 0);
+    }
+
+    #[test]
+    fn jump_to_global_session_picks_global_claude_md() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 3; // GLOBAL session
+        // Perturb initial Memory-mode state so the test actually verifies the jump.
+        app.project_index = 2;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Memory);
+        assert_eq!(app.project_index, 0);
+        assert_eq!(
+            app.projects[app.project_index].files[app.file_index].kind,
+            FileKind::GlobalClaudeMd
+        );
+    }
+
+    #[test]
+    fn jump_with_unknown_project_keeps_mode_unchanged() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 4; // nonexistent project
+        let prior_focus = app.focus;
+        let prior_project = app.project_index;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Sessions, "must stay in Sessions");
+        assert_eq!(app.focus, prior_focus);
+        assert_eq!(app.project_index, prior_project);
+    }
+
+    #[test]
+    fn jump_with_empty_session_list_is_noop() {
+        let mut app = App::new(make_jump_test_projects());
+        app.sessions.clear();
+        app.mode = AppMode::Sessions;
+        app.session_index = 0;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Sessions);
+    }
+
+    #[test]
+    fn jump_works_from_detail_pane_focus() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 0;
+        app.sessions_focus = SessionsPane::Detail;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Memory);
+        assert_eq!(app.project_index, 1);
+    }
+
+    #[test]
+    fn tab_after_jump_returns_to_sessions() {
+        let mut app = app_with_jump_fixture();
+        app.session_index = 0;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Memory);
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.mode, AppMode::Sessions);
+    }
+
+    #[test]
+    fn jump_in_memory_mode_is_ignored() {
+        // J is a Sessions-mode-only key. In Memory mode, pressing it
+        // should not crash and should not change project_index.
+        let mut app = App::new(make_jump_test_projects());
+        app.sessions = vec![make_jump_test_session("alpha")];
+        app.mode = AppMode::Memory;
+        app.project_index = 0;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Memory);
+        assert_eq!(app.project_index, 0);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -381,8 +381,7 @@ impl App {
 
 /// CLAUDE.md beats MEMORY.md because the user is asking "what does this
 /// project want me to do?" — primary instructions, not the auto-memory
-/// index. Returns `None` when `files` is empty so the caller can stay in
-/// Sessions instead of switching to a blank preview.
+/// index.
 fn pick_jump_target(files: &[MemoryFile]) -> Option<usize> {
     files
         .iter()

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,17 +179,16 @@ impl App {
                 self.wants_refresh = true;
             }
             KeyCode::Char('r') => self.wants_refresh = true,
-            KeyCode::Char('J') => self.jump_to_project_memory(self.session_index),
+            KeyCode::Char('J') => self.jump_to_project_memory(),
             _ => {}
         }
     }
 
-    /// Jump from a Sessions row to that project's memory in Memory mode.
-    /// Silent no-op if the index is out of range or the project name does
-    /// not match any scanned project (e.g. project deleted while Sessions
-    /// list still has its registry entry).
-    fn jump_to_project_memory(&mut self, session_index: usize) {
-        let Some(entry) = self.sessions.get(session_index) else {
+    /// Silent no-op if the project's registry entry outlives its scanned
+    /// directory (race after external deletion) or the matched project
+    /// has no files.
+    fn jump_to_project_memory(&mut self) {
+        let Some(entry) = self.sessions.get(self.session_index) else {
             return;
         };
         let Some(project_idx) = self
@@ -199,7 +198,9 @@ impl App {
         else {
             return;
         };
-        let file_idx = pick_jump_target(&self.projects[project_idx].files);
+        let Some(file_idx) = pick_jump_target(&self.projects[project_idx].files) else {
+            return;
+        };
 
         self.mode = AppMode::Memory;
         self.focus = Pane::Preview;
@@ -378,14 +379,16 @@ impl App {
     }
 }
 
-/// File priority for the Sessions → Memory jump:
-/// CLAUDE.md (project or global) > MEMORY.md > first file.
-fn pick_jump_target(files: &[MemoryFile]) -> usize {
+/// CLAUDE.md beats MEMORY.md because the user is asking "what does this
+/// project want me to do?" — primary instructions, not the auto-memory
+/// index. Returns `None` when `files` is empty so the caller can stay in
+/// Sessions instead of switching to a blank preview.
+fn pick_jump_target(files: &[MemoryFile]) -> Option<usize> {
     files
         .iter()
         .position(|f| matches!(f.kind, FileKind::ProjectClaudeMd | FileKind::GlobalClaudeMd))
         .or_else(|| files.iter().position(|f| f.kind == FileKind::MemoryIndex))
-        .unwrap_or(0)
+        .or_else(|| (!files.is_empty()).then_some(0))
 }
 
 #[cfg(test)]
@@ -905,7 +908,7 @@ mod tests {
     #[test]
     fn jump_switches_to_memory_mode_and_focuses_preview() {
         let mut app = app_with_jump_fixture();
-        app.session_index = 0; // alpha
+        app.session_index = 0;
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
         assert_eq!(app.mode, AppMode::Memory);
         assert_eq!(app.focus, Pane::Preview);
@@ -914,10 +917,11 @@ mod tests {
     #[test]
     fn jump_picks_project_claude_md_when_present() {
         let mut app = app_with_jump_fixture();
-        app.session_index = 0; // alpha — has CLAUDE.md at file_index 1
+        app.session_index = 0;
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
         assert_eq!(app.project_index, 1);
-        // CLAUDE.md is at index 1 in the alpha project (after notes.md at 0)
+        // alpha intentionally orders [notes.md, CLAUDE.md] so that picking
+        // by kind (not index 0) is the only way file_index=1 is reached.
         assert_eq!(app.file_index, 1);
         assert_eq!(
             app.projects[app.project_index].files[app.file_index].kind,
@@ -928,7 +932,7 @@ mod tests {
     #[test]
     fn jump_picks_memory_index_when_no_claude_md() {
         let mut app = app_with_jump_fixture();
-        app.session_index = 1; // beta — has MEMORY.md but no CLAUDE.md
+        app.session_index = 1;
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
         assert_eq!(app.project_index, 2);
         assert_eq!(
@@ -940,7 +944,7 @@ mod tests {
     #[test]
     fn jump_picks_first_file_when_no_claude_or_memory_index() {
         let mut app = app_with_jump_fixture();
-        app.session_index = 2; // gamma — only generic memory files
+        app.session_index = 2;
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
         assert_eq!(app.project_index, 3);
         assert_eq!(app.file_index, 0);
@@ -949,8 +953,9 @@ mod tests {
     #[test]
     fn jump_to_global_session_picks_global_claude_md() {
         let mut app = app_with_jump_fixture();
-        app.session_index = 3; // GLOBAL session
-        // Perturb initial Memory-mode state so the test actually verifies the jump.
+        app.session_index = 3;
+        // Perturb initial Memory-mode state so the test actually verifies
+        // the jump (otherwise project_index=0 trivially holds).
         app.project_index = 2;
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
         assert_eq!(app.mode, AppMode::Memory);
@@ -964,11 +969,11 @@ mod tests {
     #[test]
     fn jump_with_unknown_project_keeps_mode_unchanged() {
         let mut app = app_with_jump_fixture();
-        app.session_index = 4; // nonexistent project
+        app.session_index = 4;
         let prior_focus = app.focus;
         let prior_project = app.project_index;
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
-        assert_eq!(app.mode, AppMode::Sessions, "must stay in Sessions");
+        assert_eq!(app.mode, AppMode::Sessions);
         assert_eq!(app.focus, prior_focus);
         assert_eq!(app.project_index, prior_project);
     }
@@ -1005,8 +1010,6 @@ mod tests {
 
     #[test]
     fn jump_in_memory_mode_is_ignored() {
-        // J is a Sessions-mode-only key. In Memory mode, pressing it
-        // should not crash and should not change project_index.
         let mut app = App::new(make_jump_test_projects());
         app.sessions = vec![make_jump_test_session("alpha")];
         app.mode = AppMode::Memory;
@@ -1014,5 +1017,21 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
         assert_eq!(app.mode, AppMode::Memory);
         assert_eq!(app.project_index, 0);
+    }
+
+    #[test]
+    fn jump_no_op_when_matched_project_has_no_files() {
+        // Defends the pick_jump_target Option contract: an empty files vec
+        // would otherwise switch to Memory mode with a blank preview.
+        let mut app = App::new(vec![Project {
+            name: "ghost".to_string(),
+            path: PathBuf::from("/tmp/ghost"),
+            files: vec![],
+        }]);
+        app.sessions = vec![make_jump_test_session("ghost")];
+        app.mode = AppMode::Sessions;
+        app.session_index = 0;
+        app.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        assert_eq!(app.mode, AppMode::Sessions);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -391,6 +391,7 @@ fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) 
             ("s", "sort"),
             ("S", "reverse"),
             ("r", "refresh"),
+            ("J", "jump"),
             ("Tab", "memory"),
             ("q", "quit"),
         ],


### PR DESCRIPTION
## Summary

- Sessions 모드에서 `J` 누르면 선택된 세션의 프로젝트 CLAUDE.md로 한 키스트로크 점프
- 파일 우선순위: `CLAUDE.md` (Project/Global) → `MEMORY.md` → 첫 메모리 파일
- 4-스텝 워크플로우(Tab → scroll → select → l → CLAUDE.md)를 단일 액션으로 압축
- Closes #11

## Usage

```
[Sessions mode]
↓ select a session
J            ← jump to that project's CLAUDE.md in Memory mode
Tab          ← back to Sessions
```

## Design notes

- `wants_*` 플래그 패턴 대신 **직접 메서드 호출** — 외부 리소스(terminal suspend, claude_dir) 불필요. `move_up`/`move_down` 같은 navigation 패턴과 정합.
- 매칭은 `decode_project_name()` (HANDBOOK §4.2) 기반 문자열 동등성 — 양쪽이 같은 디코더를 거치므로 신뢰 가능.
- `pick_jump_target()`이 `Option<usize>` 반환 — 빈 files 슬라이스를 papers over 하지 않고 caller에서 let-else 가드로 명시 short-circuit.
- "project not in scan" 케이스는 silent no-op (v1) — flash hint UI는 별도 인프라라 scope creep.

## Test plan

- [x] 12 unit tests in `src/app.rs::tests` (TDD)
- [x] 233/233 cargo test 통과
- [x] cargo clippy --all-targets -- -D warnings 클린
- [ ] 시각 확인: `cargo run -- --demo` → Tab → 세션 선택 → `J` 동작 + help bar에 `J jump` 노출
- [ ] Memory 모드에서 J가 무시되는지 확인