### PR TITLE
feat(memory): delete memory files with d + y/N confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Press `Tab` to switch between two modes:
 | `←→` / `hl` | Switch pane |
 | `Enter` | Enter next pane |
 | `e` | Edit selected file in `$EDITOR` |
+| `d` | Delete selected memory file (asks `y/N`; global `CLAUDE.md` is protected) |
 | `Tab` | Switch to Sessions mode |
 | `q` | Quit |
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Press `Tab` to switch between two modes:
 | `←→` / `hl` | Switch pane |
 | `Enter` | Enter next pane |
 | `e` | Edit selected file in `$EDITOR` |
-| `d` | Delete selected memory file (asks `y/N`; global `CLAUDE.md` is protected) |
+| `d` | Delete selected memory file (asks `y/N`; global `CLAUDE.md` and `MEMORY.md` index are protected) |
 | `Tab` | Switch to Sessions mode |
 | `q` | Quit |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::scan::{FileKind, Project};
+use crate::scan::{FileKind, MemoryFile, Project};
 use crate::sessions::{SessionCache, SessionEntry, SessionsSort};
 
 /// Sessions-mode refresh cadence when any session had activity in the last
@@ -53,9 +53,10 @@ pub struct App {
     pub content: String,
     pub should_quit: bool,
     pub wants_edit: bool,
-    /// Modal state — `Some(path)` when `d` has armed a delete confirmation.
-    /// While `Some`, all keys go through the y/N flow in `handle_key`.
-    pub delete_confirm: Option<PathBuf>,
+    /// Path armed by `d` and awaiting `y/N`. Stays `Option<PathBuf>` for
+    /// now because there is only one modal; if a second one lands (e.g.
+    /// rename), promote to a `Modal` enum.
+    pub(crate) delete_confirm: Option<PathBuf>,
 
     // Sessions mode
     pub mode: AppMode,
@@ -104,10 +105,13 @@ impl App {
         self.projects.get(self.project_index)
     }
 
-    pub fn selected_file_path(&self) -> Option<&Path> {
+    pub fn selected_file(&self) -> Option<&MemoryFile> {
         self.selected_project()
             .and_then(|p| p.files.get(self.file_index))
-            .map(|f| f.path.as_path())
+    }
+
+    pub fn selected_file_path(&self) -> Option<&Path> {
+        self.selected_file().map(|f| f.path.as_path())
     }
 
     pub fn load_content(&mut self) {
@@ -128,10 +132,8 @@ impl App {
             self.should_quit = true;
             return;
         }
-        // Modal: any key during a delete-confirm prompt either confirms (y)
-        // or cancels (everything else, including Tab and navigation). This
-        // sits above the Tab dispatch so the modal can't be accidentally
-        // bypassed by a mode toggle while still armed.
+        // Sits above the Tab dispatch so a mode toggle can't bypass the
+        // modal while it's armed.
         if self.delete_confirm.is_some() {
             if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y')) {
                 self.execute_delete();
@@ -154,15 +156,14 @@ impl App {
         if !matches!(self.focus, Pane::Files | Pane::Preview) {
             return;
         }
-        let Some(file) = self
-            .selected_project()
-            .and_then(|p| p.files.get(self.file_index))
-        else {
+        let Some(file) = self.selected_file() else {
             return;
         };
         // Refuse the user's main personal instructions — accidental loss
         // via TUI navigation has higher cost than the convenience of
         // in-app deletion. `rm` from a shell is still available.
+        // TODO(duru-flash-hint): surface this refusal via a flash hint
+        // once the hint subsystem lands; today the user gets no signal.
         if file.kind == FileKind::GlobalClaudeMd {
             return;
         }
@@ -180,17 +181,16 @@ impl App {
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
                 self.apply_delete_to_state(&path);
             }
-            Err(_) => {
-                // Permission denied or similar — file stays in the list,
-                // user can retry. Silent skip until a flash-hint UI lands.
-            }
+            // TODO(duru-flash-hint): surface permission/IO errors when the
+            // hint subsystem lands. Today the file stays in the list so
+            // the user can retry, but they get no signal that the attempt
+            // failed.
+            Err(_) => {}
         }
     }
 
     fn apply_delete_to_state(&mut self, path: &Path) {
-        let project_now_empty;
-        let new_files_len;
-        {
+        let (project_now_empty, new_files_len) = {
             let Some(project) = self.projects.get_mut(self.project_index) else {
                 return;
             };
@@ -198,19 +198,16 @@ impl App {
                 return;
             };
             project.files.remove(file_pos);
-            project_now_empty = project.files.is_empty();
-            new_files_len = project.files.len();
-        }
+            (project.files.is_empty(), project.files.len())
+        };
 
         if project_now_empty {
             self.projects.remove(self.project_index);
-            if self.project_index >= self.projects.len() {
-                self.project_index = self.projects.len().saturating_sub(1);
-            }
+            clamp_index(&mut self.project_index, self.projects.len());
             self.file_index = 0;
             self.focus = Pane::Projects;
-        } else if self.file_index >= new_files_len {
-            self.file_index = new_files_len - 1;
+        } else {
+            clamp_index(&mut self.file_index, new_files_len);
         }
         self.load_content();
     }
@@ -275,11 +272,7 @@ impl App {
     }
 
     pub fn clamp_session_index(&mut self) {
-        if self.sessions.is_empty() {
-            self.session_index = 0;
-        } else if self.session_index >= self.sessions.len() {
-            self.session_index = self.sessions.len() - 1;
-        }
+        clamp_index(&mut self.session_index, self.sessions.len());
     }
 
     pub fn refresh_sessions(&mut self, claude_dir: &Path) {
@@ -434,6 +427,12 @@ impl App {
             Pane::Preview => Pane::Preview,
         };
     }
+}
+
+/// Clamp an index into a Vec of length `len`. Empty Vec → index 0; in
+/// bounds → unchanged; over the end → last element.
+fn clamp_index(index: &mut usize, len: usize) {
+    *index = if len == 0 { 0 } else { (*index).min(len - 1) };
 }
 
 #[cfg(test)]
@@ -856,9 +855,8 @@ mod tests {
 
     // --- Memory file delete (issue #40) ---
 
-    /// Build an App rooted in a tempdir with one project containing the
-    /// requested files actually written to disk, so delete tests can
-    /// verify both fs removal and state mutation.
+    /// Real on-disk files so `fs::remove_file` actually has something to
+    /// remove. Returns the TempDir to keep it alive for the test scope.
     fn app_with_real_files(files: &[(FileKind, &str)]) -> (tempfile::TempDir, App) {
         let tmp = tempfile::tempdir().unwrap();
         let project_dir = tmp.path().join("proj");

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,12 +3,13 @@
 //! @tested src/app.rs#tests
 
 use std::fs;
-use std::path::Path;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::scan::Project;
+use crate::scan::{FileKind, Project};
 use crate::sessions::{SessionCache, SessionEntry, SessionsSort};
 
 /// Sessions-mode refresh cadence when any session had activity in the last
@@ -52,6 +53,9 @@ pub struct App {
     pub content: String,
     pub should_quit: bool,
     pub wants_edit: bool,
+    /// Modal state — `Some(path)` when `d` has armed a delete confirmation.
+    /// While `Some`, all keys go through the y/N flow in `handle_key`.
+    pub delete_confirm: Option<PathBuf>,
 
     // Sessions mode
     pub mode: AppMode,
@@ -78,6 +82,7 @@ impl App {
             content: String::new(),
             should_quit: false,
             wants_edit: false,
+            delete_confirm: None,
 
             mode: AppMode::Memory,
             session_cache: SessionCache::new(),
@@ -123,6 +128,18 @@ impl App {
             self.should_quit = true;
             return;
         }
+        // Modal: any key during a delete-confirm prompt either confirms (y)
+        // or cancels (everything else, including Tab and navigation). This
+        // sits above the Tab dispatch so the modal can't be accidentally
+        // bypassed by a mode toggle while still armed.
+        if self.delete_confirm.is_some() {
+            if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y')) {
+                self.execute_delete();
+            } else {
+                self.delete_confirm = None;
+            }
+            return;
+        }
         if matches!(key.code, KeyCode::Tab | KeyCode::BackTab) {
             self.toggle_mode();
             return;
@@ -131,6 +148,71 @@ impl App {
             AppMode::Memory => self.handle_key_memory(key),
             AppMode::Sessions => self.handle_key_sessions(key),
         }
+    }
+
+    fn arm_delete(&mut self) {
+        if !matches!(self.focus, Pane::Files | Pane::Preview) {
+            return;
+        }
+        let Some(file) = self
+            .selected_project()
+            .and_then(|p| p.files.get(self.file_index))
+        else {
+            return;
+        };
+        // Refuse the user's main personal instructions — accidental loss
+        // via TUI navigation has higher cost than the convenience of
+        // in-app deletion. `rm` from a shell is still available.
+        if file.kind == FileKind::GlobalClaudeMd {
+            return;
+        }
+        self.delete_confirm = Some(file.path.clone());
+    }
+
+    fn execute_delete(&mut self) {
+        let Some(path) = self.delete_confirm.take() else {
+            return;
+        };
+        match fs::remove_file(&path) {
+            Ok(_) => self.apply_delete_to_state(&path),
+            // File already gone (race with external rm) — the goal is
+            // achieved, sync state to match disk.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                self.apply_delete_to_state(&path);
+            }
+            Err(_) => {
+                // Permission denied or similar — file stays in the list,
+                // user can retry. Silent skip until a flash-hint UI lands.
+            }
+        }
+    }
+
+    fn apply_delete_to_state(&mut self, path: &Path) {
+        let project_now_empty;
+        let new_files_len;
+        {
+            let Some(project) = self.projects.get_mut(self.project_index) else {
+                return;
+            };
+            let Some(file_pos) = project.files.iter().position(|f| f.path == *path) else {
+                return;
+            };
+            project.files.remove(file_pos);
+            project_now_empty = project.files.is_empty();
+            new_files_len = project.files.len();
+        }
+
+        if project_now_empty {
+            self.projects.remove(self.project_index);
+            if self.project_index >= self.projects.len() {
+                self.project_index = self.projects.len().saturating_sub(1);
+            }
+            self.file_index = 0;
+            self.focus = Pane::Projects;
+        } else if self.file_index >= new_files_len {
+            self.file_index = new_files_len - 1;
+        }
+        self.load_content();
     }
 
     fn toggle_mode(&mut self) {
@@ -279,6 +361,7 @@ impl App {
                     self.wants_edit = true;
                 }
             }
+            KeyCode::Char('d') => self.arm_delete(),
             _ => {}
         }
     }
@@ -769,5 +852,211 @@ mod tests {
             files: vec![],
         }]);
         assert_eq!(app.selected_file_path(), None);
+    }
+
+    // --- Memory file delete (issue #40) ---
+
+    /// Build an App rooted in a tempdir with one project containing the
+    /// requested files actually written to disk, so delete tests can
+    /// verify both fs removal and state mutation.
+    fn app_with_real_files(files: &[(FileKind, &str)]) -> (tempfile::TempDir, App) {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("proj");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let memory_files: Vec<MemoryFile> = files
+            .iter()
+            .map(|(kind, name)| {
+                let path = project_dir.join(name);
+                std::fs::write(&path, b"test content").unwrap();
+                MemoryFile {
+                    kind: kind.clone(),
+                    path,
+                    name: name.to_string(),
+                    size: 12,
+                }
+            })
+            .collect();
+
+        let mut app = App::new(vec![Project {
+            name: "proj".to_string(),
+            path: project_dir,
+            files: memory_files,
+        }]);
+        app.focus = Pane::Files;
+        (tmp, app)
+    }
+
+    #[test]
+    fn delete_d_arms_confirm_when_on_memory_file() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_some());
+    }
+
+    #[test]
+    fn delete_armed_holds_path_of_selected_file() {
+        let (_tmp, mut app) = app_with_real_files(&[
+            (FileKind::ProjectClaudeMd, "CLAUDE.md"),
+            (FileKind::Memory, "notes.md"),
+        ]);
+        app.file_index = 1;
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert_eq!(
+            app.delete_confirm.as_ref().and_then(|p| p.file_name()),
+            Some(std::ffi::OsStr::new("notes.md"))
+        );
+    }
+
+    #[test]
+    fn delete_d_ignored_in_projects_pane() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        app.focus = Pane::Projects;
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_none());
+    }
+
+    #[test]
+    fn delete_d_ignored_when_no_file_selected() {
+        let mut app = App::new(vec![Project {
+            name: "empty".to_string(),
+            path: PathBuf::from("/tmp/empty-del"),
+            files: vec![],
+        }]);
+        app.focus = Pane::Files;
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_none());
+    }
+
+    #[test]
+    fn delete_refuses_global_claude_md() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::GlobalClaudeMd, "CLAUDE.md")]);
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(
+            app.delete_confirm.is_none(),
+            "global CLAUDE.md must not be deletable from duru"
+        );
+    }
+
+    #[test]
+    fn delete_y_after_arm_removes_file_from_disk() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        let path = app.selected_file_path().unwrap().to_path_buf();
+        assert!(path.exists());
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert!(!path.exists(), "file should be removed from disk");
+        assert!(app.delete_confirm.is_none(), "modal must clear after confirm");
+    }
+
+    #[test]
+    fn delete_y_after_arm_removes_file_from_project_state() {
+        let (_tmp, mut app) = app_with_real_files(&[
+            (FileKind::Memory, "a.md"),
+            (FileKind::Memory, "b.md"),
+        ]);
+        app.file_index = 0; // delete a.md
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert_eq!(app.projects[0].files.len(), 1);
+        assert_eq!(app.projects[0].files[0].name, "b.md");
+    }
+
+    #[test]
+    fn delete_n_cancels_confirm() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        let path = app.selected_file_path().unwrap().to_path_buf();
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_none());
+        assert!(path.exists(), "file must still exist after cancel");
+    }
+
+    #[test]
+    fn delete_arbitrary_key_cancels_confirm() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        // a navigation key should also cancel
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_none());
+    }
+
+    #[test]
+    fn delete_clamps_file_index_when_last_file_removed() {
+        let (_tmp, mut app) = app_with_real_files(&[
+            (FileKind::Memory, "a.md"),
+            (FileKind::Memory, "b.md"),
+        ]);
+        app.file_index = 1; // delete the last file
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert_eq!(app.projects[0].files.len(), 1);
+        assert_eq!(
+            app.file_index, 0,
+            "file_index must clamp to last valid position"
+        );
+    }
+
+    #[test]
+    fn delete_removes_project_when_last_file_removed() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "lone.md")]);
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert!(
+            app.projects.is_empty(),
+            "empty project must disappear from scan"
+        );
+        assert_eq!(app.focus, Pane::Projects, "focus must retreat from Files");
+    }
+
+    #[test]
+    fn delete_treats_already_gone_file_as_success() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "racing.md")]);
+        let path = app.selected_file_path().unwrap().to_path_buf();
+        std::fs::remove_file(&path).unwrap(); // race: gone before confirm
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert!(
+            app.projects.is_empty() || app.projects[0].files.is_empty(),
+            "state must update even when file was already gone"
+        );
+    }
+
+    #[test]
+    fn tab_during_delete_confirm_clears_confirm() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_some());
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert!(
+            app.delete_confirm.is_none(),
+            "Tab must not leave the modal hanging"
+        );
+    }
+
+    #[test]
+    fn delete_d_ignored_in_sessions_mode() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        app.mode = AppMode::Sessions;
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(app.delete_confirm.is_none());
+    }
+
+    #[test]
+    fn delete_d_works_from_preview_pane() {
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
+        app.focus = Pane::Preview;
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(
+            app.delete_confirm.is_some(),
+            "delete should be reachable from Preview, matching `e` (edit)"
+        );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -159,12 +159,13 @@ impl App {
         let Some(file) = self.selected_file() else {
             return;
         };
-        // Refuse the user's main personal instructions — accidental loss
-        // via TUI navigation has higher cost than the convenience of
-        // in-app deletion. `rm` from a shell is still available.
+        // GlobalClaudeMd: user's main personal instructions — accidental
+        // loss is high-cost. MemoryIndex (MEMORY.md): deleting orphans
+        // every memory file the index references; the auto-memory tree
+        // breaks invisibly. Both stay deletable from a shell.
         // TODO(duru-flash-hint): surface this refusal via a flash hint
         // once the hint subsystem lands; today the user gets no signal.
-        if file.kind == FileKind::GlobalClaudeMd {
+        if matches!(file.kind, FileKind::GlobalClaudeMd | FileKind::MemoryIndex) {
             return;
         }
         self.delete_confirm = Some(file.path.clone());
@@ -175,7 +176,7 @@ impl App {
             return;
         };
         match fs::remove_file(&path) {
-            Ok(_) => self.apply_delete_to_state(&path),
+            Ok(()) => self.apply_delete_to_state(&path),
             // File already gone (race with external rm) — the goal is
             // achieved, sync state to match disk.
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
@@ -937,6 +938,18 @@ mod tests {
     }
 
     #[test]
+    fn delete_refuses_memory_index() {
+        // MEMORY.md indexes the auto-memory tree — deleting it orphans
+        // every memory file it references.
+        let (_tmp, mut app) = app_with_real_files(&[(FileKind::MemoryIndex, "MEMORY.md")]);
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(
+            app.delete_confirm.is_none(),
+            "MEMORY.md must not be deletable from duru"
+        );
+    }
+
+    #[test]
     fn delete_y_after_arm_removes_file_from_disk() {
         let (_tmp, mut app) = app_with_real_files(&[(FileKind::Memory, "notes.md")]);
         let path = app.selected_file_path().unwrap().to_path_buf();
@@ -946,15 +959,16 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
 
         assert!(!path.exists(), "file should be removed from disk");
-        assert!(app.delete_confirm.is_none(), "modal must clear after confirm");
+        assert!(
+            app.delete_confirm.is_none(),
+            "modal must clear after confirm"
+        );
     }
 
     #[test]
     fn delete_y_after_arm_removes_file_from_project_state() {
-        let (_tmp, mut app) = app_with_real_files(&[
-            (FileKind::Memory, "a.md"),
-            (FileKind::Memory, "b.md"),
-        ]);
+        let (_tmp, mut app) =
+            app_with_real_files(&[(FileKind::Memory, "a.md"), (FileKind::Memory, "b.md")]);
         app.file_index = 0; // delete a.md
         app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
@@ -984,10 +998,8 @@ mod tests {
 
     #[test]
     fn delete_clamps_file_index_when_last_file_removed() {
-        let (_tmp, mut app) = app_with_real_files(&[
-            (FileKind::Memory, "a.md"),
-            (FileKind::Memory, "b.md"),
-        ]);
+        let (_tmp, mut app) =
+            app_with_real_files(&[(FileKind::Memory, "a.md"), (FileKind::Memory, "b.md")]);
         app.file_index = 1; // delete the last file
         app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -378,10 +378,7 @@ fn render_preview_pane(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 
 fn render_help_bar(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     if let Some(path) = &app.delete_confirm {
-        let filename = path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_default();
+        let filename = path.file_name().unwrap_or_default().to_string_lossy();
         let prompt = format!(" Delete {filename}? (y/N)");
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -37,7 +37,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &Theme) {
         AppMode::Sessions => render_sessions_layout(frame, app, theme, outer[1]),
     }
 
-    render_help_bar(frame, app.mode, theme, outer[2]);
+    render_help_bar(frame, app, theme, outer[2]);
 }
 
 fn render_memory_layout(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
@@ -376,12 +376,30 @@ fn render_preview_pane(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
     frame.render_widget(paragraph, area);
 }
 
-fn render_help_bar(frame: &mut Frame, mode: AppMode, theme: &Theme, area: Rect) {
-    let entries: &[(&str, &str)] = match mode {
+fn render_help_bar(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    if let Some(path) = &app.delete_confirm {
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let prompt = format!(" Delete {filename}? (y/N)");
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                prompt,
+                Style::default().fg(theme.love).add_modifier(Modifier::BOLD),
+            )))
+            .style(Style::default().bg(theme.surface)),
+            area,
+        );
+        return;
+    }
+
+    let entries: &[(&str, &str)] = match app.mode {
         AppMode::Memory => &[
             ("↑↓", "navigate"),
             ("←→", "pane"),
             ("e", "edit"),
+            ("d", "delete"),
             ("Tab", "sessions"),
             ("q", "quit"),
         ],


### PR DESCRIPTION
## Summary

- Memory 모드 Files/Preview pane에서 `d` 누르면 confirmation prompt가 help bar에 표시
- `y`로 확정 → `fs::remove_file` + state 동기화. 다른 키는 모두 cancel
- 글로벌 `CLAUDE.md`는 보호 — accidental loss 방지
- Closes #40

## Usage

```
[Memory mode]
→ Files pane → select a memory file
d            ← help bar shows "Delete <filename>? (y/N)"
y            ← deletes the file, refreshes the project's file list
n / Esc / j  ← cancel (any non-y key)
```

## Design notes

- **Modal at top-level** in `handle_key` — armed 상태에선 모든 키가 confirm/cancel만 처리. Tab dispatch 위에 둬서 mode 토글로 modal 우회 차단.
- **동기 실행** — `fs::remove_file` 빠르고 터미널 suspend 불필요. `wants_*` 플래그 대신 직접 호출 (load_content와 같은 결).
- **Global CLAUDE.md 보호** — `FileKind::GlobalClaudeMd`는 arm 단계에서 거부.
- **Hard delete** — `trash` crate는 플랫폼별 코드 경로 추가가 작은 surface 대비 과함. 메모리 파일은 일반적으로 재생성 가능.
- **빈 프로젝트 cleanup** — 마지막 파일 삭제 시 프로젝트가 list에서 빠지고 focus가 Projects pane으로 후퇴. `clamp_index()` 헬퍼로 indices 안전 클램프.
- **`NotFound` = 성공 처리** — 외부 `rm`과의 race 시 state만 동기화. permission/IO 에러는 silent skip (`TODO(duru-flash-hint):` 마커로 향후 sweep 가능).

## Test plan

- [x] 15 unit tests in `src/app.rs::tests` (TDD, tempfile fixture)
- [x] 233/233 cargo test 통과
- [x] cargo clippy --all-targets -- -D warnings 클린
- [ ] 시각 확인: `cargo run -- --demo` → Files pane에서 파일 선택 → `d` 누르고 prompt 노출 확인 → `y` / `n` 양쪽 동작
- [ ] 글로벌 `CLAUDE.md` 위에서 `d` 무시되는지
- [ ] 마지막 파일 삭제 시 프로젝트 disappear + focus 후퇴